### PR TITLE
Update object_validator.go

### DIFF
--- a/object_validator.go
+++ b/object_validator.go
@@ -94,6 +94,10 @@ func (o *objectValidator) Validate(data interface{}) *Result {
 					res.Merge(NewSchemaValidator(o.AdditionalProperties.Schema, o.Root, o.Path+"."+key, o.KnownFormats).Validate(value))
 				} else if regularProperty && !(matched || succeededOnce) {
 					res.AddErrors(errors.FailedAllPatternProperties(o.Path, o.In, key))
+				} else {
+					//ran into an issue where passing a key not described in the body definition was making a pass 
+					//all the way through. I added this else and it fixed it. 
+					res.AddErrors(errors.PropertyNotAllowed(o.Path, o.In, key))
 				}
 			}
 		}


### PR DESCRIPTION
could pass keys not defined in a definition. I converted a posted body from an api to map[string]interface{}. I was then able to pass keys not described in my body object. Adding the else fixed. I opted for a "forbidden field".