### PR TITLE
add tests for issue 6

### DIFF
--- a/fixtures/bugs/6/empty-responses.json
+++ b/fixtures/bugs/6/empty-responses.json
@@ -1,0 +1,15 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "0.0.1",
+        "title": "test of Swagger invalid no responses"
+    },
+    "paths": {
+        "/foo": {
+            "get": {
+                "description": "foo",
+                "responses": {}
+            }
+        }
+    }
+}

--- a/fixtures/bugs/6/no-responses.json
+++ b/fixtures/bugs/6/no-responses.json
@@ -1,0 +1,14 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "0.0.1",
+        "title": "test of Swagger invalid no responses"
+    },
+    "paths": {
+        "/foo": {
+            "get": {
+                "description": "foo"
+            }
+        }
+    }
+}

--- a/spec_test.go
+++ b/spec_test.go
@@ -161,6 +161,21 @@ func TestIssue123(t *testing.T) {
 	}
 }
 
+func TestIssue6(t *testing.T) {
+	files, _ := filepath.Glob(filepath.Join("fixtures", "bugs", "6", "*.json"))
+	for _, path := range files {
+		doc, err := loads.Spec(path)
+		if assert.NoError(t, err) {
+			validator := NewSpecValidator(doc.Schema(), strfmt.Default)
+			res, _ := validator.Validate(doc)
+			for _, e := range res.Errors {
+				log.Println(e)
+			}
+			assert.False(t, res.IsValid())
+		}
+	}
+}
+
 // check if invalid patterns are indeed invalidated
 func TestIssue18(t *testing.T) {
 	files, _ := filepath.Glob(filepath.Join("fixtures", "bugs", "18", "*.json"))


### PR DESCRIPTION
Issue #6 was already fixed in latest version of `go-openapi/validate`.

Added a unit test and fixtures to proof it, and to keep it being fixed in the future.

closes #6 