### PR TITLE
Prototype: Add defaulter support

### DIFF
--- a/defaulter_test.go
+++ b/defaulter_test.go
@@ -1,0 +1,53 @@
+package validate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-openapi/spec"
+	"github.com/go-openapi/strfmt"
+)
+
+var defaulterFixturesPath = filepath.Join("fixtures", "defaulting")
+
+func TestDefaulter(t *testing.T) {
+	fname := filepath.Join(defaulterFixturesPath, "schema.json")
+	b, err := ioutil.ReadFile(fname)
+	assert.NoError(t, err)
+	var schema spec.Schema
+	assert.NoError(t, json.Unmarshal(b, &schema))
+
+	err = spec.ExpandSchema(&schema, nil, nil /*new(noopResCache)*/)
+	assert.NoError(t, err, fname+" should expand cleanly")
+
+	validator := NewSchemaValidator(&schema, nil, "", strfmt.Default)
+	x := map[string]interface{}{
+		"nested": map[string]interface{}{},
+		"all":    map[string]interface{}{},
+		"any":    map[string]interface{}{},
+		"one":    map[string]interface{}{},
+	}
+	t.Logf("Before: %v", x)
+	r := validator.Validate(x)
+	assert.False(t, r.HasErrors(), fmt.Sprintf("unexpected validation error: %v", r.AsError()))
+
+	r.ApplyDefaults()
+	t.Logf("After: %v", x)
+	var expected interface{}
+	err = json.Unmarshal([]byte(`{
+		"int": 42,
+		"str": "Hello",
+		"obj": {"foo": "bar"},
+		"nested": {"inner": 7},
+		"all": {"foo": 42, "bar": 42},
+		"any": {"foo": 42},
+		"one": {"bar": 42}
+	}`), &expected)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, x)
+}

--- a/fixtures/defaulting/schema.json
+++ b/fixtures/defaulting/schema.json
@@ -1,0 +1,101 @@
+{
+  "properties": {
+    "int": {
+      "type": "integer",
+      "default": 42
+    },
+    "str": {
+      "type": "string",
+      "minLength": 4,
+      "default": "Hello"
+    },
+    "obj": {
+      "type": "object",
+      "default": {"foo": "bar"}
+    },
+    "nested": {
+      "type": "object",
+      "properties": {
+        "inner": {
+          "type": "integer",
+          "default": 7
+        }
+      }
+    },
+    "all": {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "type": "integer",
+              "default": 42
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "bar": {
+              "type": "integer",
+              "default": 42
+            }
+          }
+        }
+      ]
+    },
+    "any": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "type": "integer",
+              "default": 42
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "bar": {
+              "type": "integer",
+              "default": 42
+            }
+          }
+        }
+      ]
+    },
+    "one": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "type": "integer"
+            }
+          },
+          "required": ["foo"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "bar": {
+              "type": "integer",
+              "default": 42
+            }
+          }
+        }
+      ]
+    },
+    "not": {
+      "not": {
+        "type": "object",
+        "default": {
+          "foo": 1
+        }
+      }
+    }
+  },
+  "required": ["int", "str", "nested", "all", "any", "one"]
+}

--- a/result.go
+++ b/result.go
@@ -25,10 +25,21 @@ var (
 	Debug = os.Getenv("SWAGGER_DEBUG") != ""
 )
 
+type Defaulter interface {
+	Apply()
+}
+
+type DefaulterFunc func()
+
+func (f DefaulterFunc) Apply() {
+	f()
+}
+
 // Result represents a validation result
 type Result struct {
 	Errors     []error
 	MatchCount int
+	Defaulters []Defaulter
 }
 
 // Merge merges this result with the other one, preserving match counts etc
@@ -38,6 +49,7 @@ func (r *Result) Merge(other *Result) *Result {
 	}
 	r.AddErrors(other.Errors...)
 	r.MatchCount += other.MatchCount
+	r.Defaulters = append(r.Defaulters, other.Defaulters...)
 	return r
 }
 
@@ -67,4 +79,10 @@ func (r *Result) AsError() error {
 		return nil
 	}
 	return errors.CompositeValidationError(r.Errors...)
+}
+
+func (r *Result) ApplyDefaults() {
+	for _, d := range r.Defaulters {
+		d.Apply()
+	}
 }

--- a/schema.go
+++ b/schema.go
@@ -148,7 +148,6 @@ func (s *SchemaValidator) commonValidator() valueValidator {
 	return &basicCommonValidator{
 		Path:    s.Path,
 		In:      s.in,
-		Default: s.Schema.Default,
 		Enum:    s.Schema.Enum,
 	}
 }
@@ -184,7 +183,6 @@ func (s *SchemaValidator) stringValidator() valueValidator {
 	return &stringValidator{
 		Path:      s.Path,
 		In:        s.in,
-		Default:   s.Schema.Default,
 		MaxLength: s.Schema.MaxLength,
 		MinLength: s.Schema.MinLength,
 		Pattern:   s.Schema.Pattern,
@@ -195,7 +193,6 @@ func (s *SchemaValidator) formatValidator() valueValidator {
 	return &formatValidator{
 		Path: s.Path,
 		In:   s.in,
-		//Default:      s.Schema.Default,
 		Format:       s.Schema.Format,
 		KnownFormats: s.KnownFormats,
 	}

--- a/schema_props.go
+++ b/schema_props.go
@@ -89,6 +89,7 @@ func (s *schemaPropsValidator) Applies(source interface{}, kind reflect.Kind) bo
 
 func (s *schemaPropsValidator) Validate(data interface{}) *Result {
 	mainResult := new(Result)
+	var firstSuccess *Result
 	if len(s.anyOfValidators) > 0 {
 		var bestFailures *Result
 		succeededOnce := false
@@ -97,6 +98,9 @@ func (s *schemaPropsValidator) Validate(data interface{}) *Result {
 			if result.IsValid() {
 				bestFailures = nil
 				succeededOnce = true
+				if firstSuccess == nil {
+					firstSuccess = result
+				}
 				break
 			}
 			if bestFailures == nil || result.MatchCount > bestFailures.MatchCount {
@@ -109,11 +113,14 @@ func (s *schemaPropsValidator) Validate(data interface{}) *Result {
 		}
 		if bestFailures != nil {
 			mainResult.Merge(bestFailures)
+		} else if firstSuccess != nil {
+			mainResult.Merge(firstSuccess)
 		}
 	}
 
 	if len(s.oneOfValidators) > 0 {
 		var bestFailures *Result
+		var firstSuccess *Result
 		validated := 0
 
 		for _, oneOfSchema := range s.oneOfValidators {
@@ -121,6 +128,9 @@ func (s *schemaPropsValidator) Validate(data interface{}) *Result {
 			if result.IsValid() {
 				validated++
 				bestFailures = nil
+				if firstSuccess == nil {
+					firstSuccess = result
+				}
 				continue
 			}
 			if validated == 0 && (bestFailures == nil || result.MatchCount > bestFailures.MatchCount) {
@@ -133,6 +143,8 @@ func (s *schemaPropsValidator) Validate(data interface{}) *Result {
 			if bestFailures != nil {
 				mainResult.Merge(bestFailures)
 			}
+		} else if firstSuccess != nil {
+			mainResult.Merge(firstSuccess)
 		}
 	}
 


### PR DESCRIPTION
We plan to use go-openapi for CustomResourceDefinition validation in Kubernetes (compare https://github.com/kubernetes/community/pull/708). For that will need support for default values. This is a prototype to integrate this into go-openapi.