### PR TITLE
Spec Validate function returns validated spec document

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -48,10 +48,12 @@ import (
 // 	- every default value that is specified must validate against the schema for that property
 // 	- items property is required for all schemas/definitions of type `array`
 func Spec(doc *loads.Document, formats strfmt.Registry) error {
-	errs, _ /*warns*/ := NewSpecValidator(doc.Schema(), formats).Validate(doc)
+   newSpecValidator := NewSpecValidator(doc.Schema(), formats)
+   errs, _ /*warns*/ := newSpecValidator.Validate(doc)
 	if errs.HasErrors() {
 		return errors.CompositeValidationError(errs.Errors...)
 	}
+   *doc = *(newSpecValidator.expanded)
 	return nil
 }
 


### PR DESCRIPTION
Returns validated spec with expanded jsonrefs as an out parameter of
function Spec.

This in reference to fix for an issue in go-swagger 

fixes go-swagger/go-swagger#890