### PR TITLE
Revert "Spec Validate function returns validated spec document"

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -48,12 +48,10 @@ import (
 // 	- every default value that is specified must validate against the schema for that property
 // 	- items property is required for all schemas/definitions of type `array`
 func Spec(doc *loads.Document, formats strfmt.Registry) error {
-   newSpecValidator := NewSpecValidator(doc.Schema(), formats)
-   errs, _ /*warns*/ := newSpecValidator.Validate(doc)
+	errs, _ /*warns*/ := NewSpecValidator(doc.Schema(), formats).Validate(doc)
 	if errs.HasErrors() {
 		return errors.CompositeValidationError(errs.Errors...)
 	}
-   *doc = *(newSpecValidator.expanded)
 	return nil
 }
 


### PR DESCRIPTION
Reverts go-openapi/validate#28

This is not required for go-swagger issue (go-swagger/go-swagger#890) . Post validation we flatten the spec from original spec. Validation returning a modified spec has no use.

Go-swagger works and passes all test without this change. (Verified with vendor file change locally)
Safe to revert.