### PR TITLE
check that any object with items key have a type array

### DIFF
--- a/object_validator.go
+++ b/object_validator.go
@@ -65,6 +65,15 @@ func (o *objectValidator) Validate(data interface{}) *Result {
 
 	res := new(Result)
 
+	// This is to check that the items keyword is only valid for array types
+	if _, itemsKeyFound := val["items"]; itemsKeyFound {
+		if t, typeFound := val["type"]; typeFound {
+			if tpe, ok := t.(string); !ok || tpe != "array" {
+				res.AddErrors(errors.InvalidType(o.Path, o.In, "array", nil))
+			}
+		}
+	}
+
 	if o.AdditionalProperties != nil && !o.AdditionalProperties.Allows {
 		for k := range val {
 			_, regularProperty := o.Properties[k]

--- a/object_validator_test.go
+++ b/object_validator_test.go
@@ -1,0 +1,34 @@
+// Copyright 2017 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import "testing"
+import "github.com/stretchr/testify/assert"
+
+func TestItemsMustBeTypeArray(t *testing.T) {
+	ov := new(objectValidator)
+	dataValid := map[string]interface{}{
+		"type":  "array",
+		"items": "dummy",
+	}
+	dataInvalid := map[string]interface{}{
+		"type":  "object",
+		"items": "dummy",
+	}
+	res := ov.Validate(dataValid)
+	assert.Equal(t, 0, len(res.Errors))
+	res = ov.Validate(dataInvalid)
+	assert.NotEqual(t, 0, len(res.Errors))
+}


### PR DESCRIPTION
Added a type check when encountering the `items` keyword to make sure that the type is array. 