### PR TITLE
Fix panic for nil schema

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -82,12 +82,16 @@ func (s *SchemaValidator) Applies(source interface{}, kind reflect.Kind) bool {
 
 // Validate validates the data against the schema
 func (s *SchemaValidator) Validate(data interface{}) *Result {
+	result := new(Result)
+	if s == nil {
+		return result
+	}
+
 	if data == nil {
 		v := s.validators[0].Validate(data)
 		v.Merge(s.validators[6].Validate(data))
 		return v
 	}
-	result := new(Result)
 
 	tpe := reflect.TypeOf(data)
 	kind := tpe.Kind()
@@ -146,9 +150,9 @@ func (s *SchemaValidator) typeValidator() valueValidator {
 
 func (s *SchemaValidator) commonValidator() valueValidator {
 	return &basicCommonValidator{
-		Path:    s.Path,
-		In:      s.in,
-		Enum:    s.Schema.Enum,
+		Path: s.Path,
+		In:   s.in,
+		Enum: s.Schema.Enum,
 	}
 }
 
@@ -191,8 +195,8 @@ func (s *SchemaValidator) stringValidator() valueValidator {
 
 func (s *SchemaValidator) formatValidator() valueValidator {
 	return &formatValidator{
-		Path: s.Path,
-		In:   s.in,
+		Path:         s.Path,
+		In:           s.in,
 		Format:       s.Schema.Format,
 		KnownFormats: s.KnownFormats,
 	}


### PR DESCRIPTION
When the input schema is nil, `NewSchemaValidator` will return a nil `*SchemaValidator`.

https://github.com/go-openapi/validate/blob/e9896c14bf42ec6181ec4aaa83640aa9f9b09e1e/schema.go#L43-L46

This nil `*SchemaValidator` is passed to `Validate`, which panics when `s.validators` is called.

https://github.com/go-openapi/validate/blob/e9896c14bf42ec6181ec4aaa83640aa9f9b09e1e/schema.go#L84

https://github.com/go-openapi/validate/blob/e9896c14bf42ec6181ec4aaa83640aa9f9b09e1e/schema.go#L127

While fixing this, I believe we should not return a `nil` for `*Result` because when `result.AsError()` is called by the user, it will panic here:

https://github.com/go-openapi/validate/blob/e9896c14bf42ec6181ec4aaa83640aa9f9b09e1e/result.go#L64