### PR TITLE
Fixed panic case on response + more testing on formats

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -15,8 +15,11 @@
 package validate
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"path/filepath"
+	"runtime"
 )
 
 var (
@@ -31,14 +34,16 @@ func init() {
 
 func debugOptions() {
 	if Debug {
-		log.SetFlags(log.LstdFlags | log.Lshortfile)
-		log.SetPrefix("validate")
+		//log.SetFlags(log.LstdFlags | log.Lshortfile)
+		log.SetFlags(log.LstdFlags)
+		log.SetPrefix("validate:")
 	}
 }
 
 func debugLog(msg string, args ...interface{}) {
 	// A private, trivial trace logger, based on go-openapi/spec/expander.go:debugLog()
 	if Debug {
-		log.Printf(msg, args...)
+		_, file1, pos1, _ := runtime.Caller(1)
+		log.Printf("%s:%d: %s", filepath.Base(file1), pos1, fmt.Sprintf(msg, args...))
 	}
 }

--- a/fixtures/formats/extended-format.json
+++ b/fixtures/formats/extended-format.json
@@ -1,0 +1,521 @@
+[
+    {
+        "description": "Sanity check: validation of date-time strings",
+        "schema": {"format": "date-time"},
+        "tests": [
+            {
+                "description": "a valid date-time string",
+                "data": "1963-06-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string",
+                "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350T01:01:01",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of date strings",
+        "schema": {"format": "date"},
+        "tests": [
+            {
+                "description": "a valid date string",
+                "data": "1963-06-19",
+                "valid": true
+            },
+            {
+                "description": "invalid month in date",
+                "data": "1963-13-19",
+                "valid": false
+            },
+            {
+                "description": "invalid day in date",
+                "data": "1963-12-39",
+                "valid": false
+            },
+            {
+                "description": "invalid year in date",
+                "data": "63-12-39",
+                "valid": false
+            },
+            {
+                "description": "invalid leap year date",
+                "data": "1999-02-29",
+                "valid": false
+            },
+            {
+                "description": "date does not validate date-time",
+                "data": "1963-06-19T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid date",
+                "data": "2013-350T01:01:01",
+                "valid": false
+            },
+            {
+                "description": "an invalid date string",
+                "data": "06/19/1963",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350T01:01:01",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "sanity check: validation of URIs (literally from json schema test suite)",
+        "schema": {"format": "uri"},
+        "tests": [
+            {
+                "description": "a valid URI",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI though valid URI reference",
+                "data": "abc",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "sanity check: validation of e-mail addresses (literally from json schema test suite)",
+        "schema": {"format": "email"},
+        "tests": [
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "sanity check: validation of IP addresses (literally from json schema test suite)",
+        "schema": {"format": "ipv4"},
+        "tests": [
+            {
+                "description": "a valid IP address",
+                "data": "192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "an IP address with too many components",
+                "data": "127.0.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "an IP address with out-of-range values",
+                "data": "256.256.256.256",
+                "valid": false
+            },
+            {
+                "description": "an IP address without 4 components",
+                "data": "127.0",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer",
+                "data": "0x7f000001",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "sanity check: validation of IPv6 addresses (literally from json schema test suite)",
+        "schema": {"format": "ipv6"},
+        "tests": [
+            {
+                "description": "a valid IPv6 address",
+                "data": "::1",
+                "valid": true
+            },
+            {
+                "description": "an IPv6 address with out-of-range values",
+                "data": "12345::",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address with too many components",
+                "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address containing illegal characters",
+                "data": "::laptop",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "sanity check: validation of host names (literally from json schema test suite)",
+        "schema": {"format": "hostname"},
+        "tests": [
+            {
+                "description": "a valid host name",
+                "data": "www.example.com",
+                "valid": true
+            },
+            {
+                "description": "a host name starting with an illegal character",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": false
+            },
+            {
+                "description": "a host name containing illegal characters",
+                "data": "not_a_valid_host_name",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of duration strings",
+        "schema": {"format": "duration"},
+        "tests": [
+            {
+                "description": "a valid duration string",
+                "data": "1ns",
+                "valid": true
+            },
+            {
+                "description": "a valid duration string",
+                "data": "1min",
+                "valid": true
+            },
+            {
+                "description": "a valid duration string",
+                "data": "1wk",
+                "valid": true
+            },
+            {
+                "description": "a valid duration string",
+                "data": "3week",
+                "valid": true
+            },
+            {
+                "description": "a valid duration string",
+                "data": "3 week",
+                "valid": true
+            },
+            {
+                "description": "a valid duration string",
+                "data": "3 weeks",
+                "valid": true
+            },
+            {
+                "description": "a valid duration string",
+                "data": "three weeks",
+                "valid": false
+            },
+            {
+                "description": "an invalid duration string",
+                "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "an invalid duration string",
+                "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "an invalid duration string",
+                "data": "zorg",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of MAC address strings",
+        "schema": {"format": "mac"},
+        "tests": [
+            {
+                "description": "a valid MAC address string",
+                "data": "01:02:03:04:05:06",
+                "valid": true
+            },
+            {
+                "description": "a valid MAC address string",
+                "data": "AE:02:03:04:05:06",
+                "valid": true
+            },
+            {
+                "description": "an invalid MAC address string",
+                "data": "01:02:03:0G:05:06",
+                "valid": false
+            },
+            {
+                "description": "an invalid MAC address string",
+                "data": "01:02:03:04:05:06:07",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of uuid strings",
+        "schema": {"format": "uuid"},
+        "tests": [
+            {
+                "description": "a valid uuid",
+                "data": "a8098c1a-f86e-11da-bd1a-00112444be1e",
+                "valid": true
+            },
+            {
+                "description": "an invalid uuid",
+                "data": "a8098c1a+f86e+11da+bd1a+00112444be1e",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of uuid3 strings",
+        "schema": {"format": "uuid3"},
+        "tests": [
+            {
+                "description": "a valid uuid3",
+                "data": "bcd02e22-68f0-3046-a512-327cca9def8f",
+                "valid": true
+            },
+            {
+                "description": "an invalid uuid3",
+                "data": "not-an-uuid3",
+                "valid": false
+            },
+            {
+                "description": "an invalid uuid3",
+                "data": "bcg02e22-68f0-3046-a512-327cca9def8f",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of uuid4 strings",
+        "schema": {"format": "uuid4"},
+        "tests": [
+            {
+                "description": "a valid uuid4",
+                "data": "025b0d74-00a2-4048-bf57-227c5111bb34",
+                "valid": true
+            },
+            {
+                "description": "an invalid uuid4",
+                "data": "not-an-uuid4",
+                "valid": false
+            },
+            {
+                "description": "an invalid uuid4",
+                "data": "025b0d74-00a2-4048-bf57-227x5111bb34",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of uuid5 strings",
+        "schema": {"format": "uuid5"},
+        "tests": [
+            {
+                "description": "a valid uuid5",
+                "data": "886313e1-3b8a-5372-9b90-0c9aee199e5d",
+                "valid": true
+            },
+            {
+                "description": "an invalid uuid5",
+                "data": "886313e1/3b8a-5372/9b90/0c9aee199e5d",
+                "valid": false
+            },
+            {
+                "description": "an invalid uuid5",
+                "data": "886313h1-3b8a-5372-9b90-0c9aee199e5d",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "test password format (pass-through)",
+        "schema": {"format": "password"},
+        "tests": [
+            {
+                "description": "a valid password",
+                "data": "secret",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of ISBN strings",
+        "schema": {"format": "isbn"},
+        "tests": [
+            {
+                "description": "a valid ISBN",
+                "data": "0321751043",
+                "valid": true
+            },
+            {
+                "description": "an invalid ISBN",
+                "data": "03217510X3",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of ISBN10 strings",
+        "schema": {"format": "isbn10"},
+        "tests": [
+            {
+                "description": "a valid ISBN10",
+                "data": "0321751043",
+                "valid": true
+            },
+            {
+                "description": "an invalid ISBN10",
+                "data": "032175104300000500",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of ISBN13 strings",
+        "schema": {"format": "isbn13"},
+        "tests": [
+            {
+                "description": "a valid ISBN13",
+                "data": "978 3401013190",
+                "valid": true
+            },
+            {
+                "description": "an invalid ISBN13",
+                "data": "032175104300000500",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of creditcard strings",
+        "schema": {"format": "creditcard"},
+        "tests": [
+            {
+                "description": "a valid creditcard",
+                "data": "4111-1111-1111-1111",
+                "valid": true
+            },
+            {
+                "description": "an invalid creditcard",
+                "data": "4111-1111-1111-11A1",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of SSN strings",
+        "schema": {"format": "ssn"},
+        "tests": [
+            {
+                "description": "a valid SSN",
+                "data": "111-11-1111",
+                "valid": true
+            },
+            {
+                "description": "an invalid SSN",
+                "data": "111-111111",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of hexcolor string",
+        "schema": {"format": "hexcolor"},
+        "tests": [
+            {
+                "description": "a valid hexcolor",
+                "data": "#FFFFFF",
+                "valid": true
+            },
+            {
+                "description": "an invalid hexcolor",
+                "data": "xFFFFFF",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of RGB color strings",
+        "schema": {"format": "rgbcolor"},
+        "tests": [
+            {
+                "description": "a valid rgbcolor",
+                "data": "rgb(255,255,255)",
+                "valid": true
+            },
+            {
+                "description": "an invalid rgbcolor",
+                "data": "rgb(100,100)",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of base64 strings",
+        "schema": {"format": "byte"},
+        "tests": [
+            {
+                "description": "a valid byte (base64)",
+                "data": "ZWxpemFiZXRocG9zZXk=",
+                "valid": true
+            },
+            {
+                "description": "an invalid byte (base64)",
+                "data": "ZWxpemFiZXRocG9zZXk",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of BSON object ID strings",
+        "schema": {"format": "bsonobjectid"},
+        "tests": [
+            {
+                "description": "a valid bsonobjectid",
+                "data": "507f1f77bcf86cd799439011",
+                "valid": true
+            },
+            {
+                "description": "an invalid bsonobjectid",
+                "data": "x07f1f77bcf86cd799439011",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validation of unsupported format (pass-through)",
+        "schema": {"format": "unsupported"},
+        "tests": [
+            {
+                "description": "an invalid format (no validation)",
+                "data": "my string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/fixtures/validation/expected_messages.yaml
+++ b/fixtures/validation/expected_messages.yaml
@@ -1194,3 +1194,110 @@ gentest3.yaml:
     withContinueOnErrors: false
     isRegexp: false
   expectedWarnings: []
+fixture-all-formats.yaml:
+  comment: all custom formats as default values
+  todo:
+  expectedLoadError: false
+  expectedValid: false
+  expectedMessages:
+  # On parameters:
+  - message: 'default value for n01 in query does not validate its schema'
+  - message: 'default value for n03 in query does not validate its schema'
+  - message: 'default value for n04 in query does not validate its schema'
+  - message: 'default value for n05 in query does not validate its schema'
+  - message: 'default value for n06 in query does not validate its schema'
+  - message: 'default value for p01 in query does not validate its schema'
+  - message: 'default value for p02 in query does not validate its schema'
+  - message: 'default value for p03 in query does not validate its schema'
+  - message: 'default value for p04 in query does not validate its schema'
+  - message: 'default value for p05 in query does not validate its schema'
+  - message: 'default value for p06 in query does not validate its schema'
+  - message: 'default value for p07 in query does not validate its schema'
+  - message: 'default value for p08 in query does not validate its schema'
+  - message: 'default value for p09 in query does not validate its schema'
+  - message: 'default value for p10 in query does not validate its schema'
+  - message: 'default value for p11 in query does not validate its schema'
+  - message: 'default value for p12 in query does not validate its schema'
+  - message: 'default value for p13 in query does not validate its schema'
+  - message: 'default value for p14 in query does not validate its schema'
+  - message: 'default value for p15 in query does not validate its schema'
+  - message: 'default value for p16 in query does not validate its schema'
+  - message: 'default value for p17 in query does not validate its schema'
+  - message: 'default value for p18 in query does not validate its schema'
+  - message: 'default value for p20 in query does not validate its schema'
+  - message: 'default value for p21 in query does not validate its schema'
+  - message: 'default value for p22 in query does not validate its schema'
+  - message: 'default value for p23 in query does not validate its schema'
+  - message: 'n01 in query must be of type number: "string"'
+  - message: 'n03 in query must be of type int32: "float64"'
+  - message: 'n04 in query must be of type int64: "float64"'
+  - message: 'Checked value must be of type integer with format uint32 in n05'
+  - message: 'Checked value must be of type integer with format uint64 in n06'
+  - message: 'p01 in query must be of type byte: "ZWxpemFiZXRocG9zZXk"'
+  - message: 'p02 in query must be of type creditcard: "4111-1X11-1111-1111"'
+  - message: 'p03 in query must be of type date: "1970-13-01"'
+  - message: 'p04 in query must be of type date-time: "1963-13-19T08:30:06.283185Z"'
+  - message: 'p05 in query must be of type duration: "three weeks"'
+  - message: 'p06 in query must be of type email: "joe.bloggs-example.com"'
+  - message: 'p07 in query must be of type hexcolor: "xFFFFFF"'
+  - message: 'p08 in query must be of type hostname: "not_a_valid_hostname"'
+  - message: 'p09 in query must be of type ipv4: "192.168.0.256"'
+  - message: 'p10 in query must be of type ipv6: "o::1"'
+  - message: 'p11 in query must be of type isbn: "abc-0321751043"'
+  - message: 'p12 in query must be of type isbn10: "abc-0321751043"'
+  - message: 'p13 in query must be of type isbn13: "978|3401013190"'
+  - message: 'p14 in query must be of type mac: "01:02:03:04:05:06:07"'
+  - message: 'p15 in query must be of type bsonobjectid: "x07f1f77bcf86cd799439011"'
+  - message: 'p16 in query must be of type password: "float64"'
+  - message: 'p17 in query must be of type rgbcolor: "rgb(100,100)"'
+  - message: 'p18 in query must be of type ssn: "111-11111"'
+  - message: 'p20 in query must be of type uuid: "a8098c1a+f86e+11da+bd1a+00112444be1e"'
+  - message: 'p21 in query must be of type uuid3: "bcd02e22+68f0+3046+a512+327cca9def8f"'
+  - message: 'p22 in query must be of type uuid4: "025b0d74+00a2+4048+bf57+227c5111bb34"'
+  - message: 'p23 in query must be of type uuid5: "886313e1+3b8a+5372+9b90+0c9aee199e5d"'
+  # On schema:
+  - message: 'definitions.allformats-bad.prop01.default in body must be of type byte: "ZWxpemFiZXRocG9zZXk"'
+  - message: 'definitions.allformats-bad.prop02.default in body must be of type creditcard: "4111-1111-1111-111K"'
+  - message: 'definitions.allformats-bad.prop03.default in body must be of type date: "1970-01-32"'
+  - message: 'definitions.allformats-bad.prop04.default in body must be of type date-time: "1963-06-19T99:30:06.283185Z"'
+  - message: 'definitions.allformats-bad.prop05.default in body must be of type duration: "weeks"'
+  - message: 'definitions.allformats-bad.prop06.default in body must be of type email: "joe.bloggs-example.com"'
+  - message: 'definitions.allformats-bad.prop07.default in body must be of type hexcolor: "float64"'
+  - message: 'definitions.allformats-bad.prop08.default in body must be of type hostname: "---invalid-hostname---"'
+  - message: 'definitions.allformats-bad.prop09.default in body must be of type ipv4: "192.2.0.1.45"'
+  - message: 'definitions.allformats-bad.prop10.default in body must be of type ipv6: "x::1"'
+  - message: 'definitions.allformats-bad.prop11.default in body must be of type isbn: "X0321751043"'
+  - message: 'definitions.allformats-bad.prop12.default in body must be of type isbn10: "X0321751043"'
+  - message: 'definitions.allformats-bad.prop13.default in body must be of type isbn13: "X978 3401013190"'
+  - message: 'definitions.allformats-bad.prop14.default in body must be of type mac: "X1:02:03:04:05:06"'
+  - message: 'definitions.allformats-bad.prop15.default in body must be of type bsonobjectid: "X507f1f77bcf86cd799439011"'
+  - message: 'definitions.allformats-bad.prop16.default in body must be of type password: "float64"'
+  - message: 'definitions.allformats-bad.prop17.default in body must be of type rgbcolor: "gb(100,100,100)"'
+  - message: 'definitions.allformats-bad.prop18.default in body must be of type ssn: "Z111-11-1111"'
+  - message: 'definitions.allformats-bad.prop20.default in body must be of type uuid: "a8098c1a+f86e+11da+bd1a+00112444be1e"'
+  - message: 'definitions.allformats-bad.prop21.default in body must be of type uuid3: "bcd02e22+68f0+3046+a512+327cca9def8f"'
+  - message: 'definitions.allformats-bad.prop22.default in body must be of type uuid4: "025b0d74+00a2+4048+bf57+227c5111bb34"'
+  - message: 'definitions.allformats-bad.prop23.default in body must be of type uuid5: "886313e1+3b8a+5372+9b90+0c9aee199e5d"'
+  - message: 'definitions.allformats-bad.propn01.default in body must be of type number: "string"'
+  - message: 'definitions.allformats-bad.propn02.default in body must be of type number: "string"'
+  - message: 'definitions.allformats-bad.propn03.default in body must be of type int32: "float64"'
+  - message: 'definitions.allformats-bad.propn04.default in body must be of type int64: "float64"'
+  - message: 'definitions.allformats-bad.propn05.default in body must be of type uint32: "float64"'
+  - message: 'definitions.allformats-bad.propn06.default in body must be of type uint64: "float64"'
+  expectedWarnings: []
+fixture-bad-response.yaml:
+  comment: $ref sibling in response
+  todo:
+  expectedLoadError: false
+  expectedValid: false
+  expectedMessages:
+  - message: '"paths./fixture.get.responses.200" must validate one and only one schema (oneOf). Found none valid'
+  - message: 'paths./fixture.get.responses.200.$ref in body is a forbidden property'
+  - message: 'invalid definition as Schema for response /fixture in responses'
+    withContinueOnErrors: true
+  expectedWarnings:
+  - message: '$ref property should have no sibling in "responses"./fixture'
+    withContinueOnErrors: true
+  - message: 'definition "#/definitions/someIds" is not used anywhere'
+    withContinueOnErrors: true
+

--- a/fixtures/validation/fixture-all-formats.yaml
+++ b/fixtures/validation/fixture-all-formats.yaml
@@ -1,0 +1,593 @@
+---
+swagger: '2.0'
+info:
+  title: 'fixture to tests formats in parameters, schema objects'
+  version: '1.0'
+  description: |
+    This exercises the type and format validation based on complete spec
+produces:
+  - application/json
+paths:
+  /fixture/formats-good:
+    get:
+      operationId: op1
+      parameters:
+        - name: p01
+          in: query
+          type: string
+          format: byte
+          default: 'ZWxpemFiZXRocG9zZXk='
+        - name: p02
+          in: query
+          type: string
+          format: creditcard
+          default: '4111-1111-1111-1111'
+        - name: p03
+          in: query
+          type: string
+          format: date
+          default: 1970-01-01
+        - name: p04
+          in: query
+          type: string
+          format: date-time
+          default: '1963-06-19T08:30:06.283185Z'
+        - name: p05
+          in: query
+          type: string
+          format: duration
+          default: '3 weeks'
+        - name: p06
+          in: query
+          type: string
+          format: email
+          default: 'joe.bloggs@example.com'
+        - name: p07
+          in: query
+          type: string
+          format: hexcolor
+          default: '#FFFFFF'
+        - name: p08
+          in: query
+          type: string
+          format: hostname
+          default: 'www.example.com'
+        - name: p09
+          in: query
+          type: string
+          format: ipv4
+          default: '192.168.0.1'
+        - name: p10
+          in: query
+          type: string
+          format: ipv6
+          default:  '::1'
+        - name: p11
+          in: query
+          type: string
+          format: isbn
+          default: '0321751043'
+        - name: p12
+          in: query
+          type: string
+          format: isbn10
+          default: '0321751043'
+        - name: p13
+          in: query
+          type: string
+          format: isbn13
+          default: '978 3401013190'
+        - name: p14
+          in: query
+          type: string
+          format: mac
+          default: '01:02:03:04:05:06'
+        - name: p15
+          in: query
+          type: string
+          format: bsonobjectid
+          default: '507f1f77bcf86cd799439011'
+        - name: p16
+          in: query
+          type: string
+          format: password
+          default: 'secret'
+        - name: p17
+          in: query
+          type: string
+          format: rgbcolor
+          default: 'rgb(100,100,100)'
+        - name: p18
+          in: query
+          type: string
+          format: ssn
+          default: '111-11-1111'
+        - name: p19
+          in: query
+          type: string
+          format: uri
+          default: 'http://foo.bar/?baz=qux#quux'
+        - name: p20
+          in: query
+          type: string
+          format: uuid
+          default: 'a8098c1a-f86e-11da-bd1a-00112444be1e'
+        - name: p21
+          in: query
+          type: string
+          format: uuid3
+          default: 'bcd02e22-68f0-3046-a512-327cca9def8f'
+        - name: p22
+          in: query
+          type: string
+          format: uuid4
+          default: '025b0d74-00a2-4048-bf57-227c5111bb34'
+        - name: p23
+          in: query
+          type: string
+          format: uuid5
+          default: '886313e1-3b8a-5372-9b90-0c9aee199e5d'
+        - name: n01
+          in: query
+          type: number
+          format: float
+          default: 10.01
+        - name: n02
+          in: query
+          type: number
+          format: double
+          default: 100.99
+        - name: n03
+          in: query
+          type: integer
+          format: int32
+          default: -12
+        - name: n04
+          in: query
+          type: integer
+          format: int64
+          default: 20
+        - name: n05
+          in: query
+          type: integer
+          format: uint32
+          default: 20
+        - name: n06
+          in: query
+          type: integer
+          format: uint64
+          default: 30
+          # TODO: check format aliases
+      responses:
+        200:
+          description: 'response exercising formats'
+          # TODO: check format in headers
+          schema:
+            $ref: '#/definitions/allformats'
+
+  /fixture/formats-bad:
+    get:
+      operationId: op2
+      parameters:
+        - name: p01
+          in: query
+          type: string
+          format: byte
+          default: 'ZWxpemFiZXRocG9zZXk'
+        - name: p02
+          in: query
+          type: string
+          format: creditcard
+          default: '4111-1X11-1111-1111'
+        - name: p03
+          in: query
+          type: string
+          format: date
+          default: 1970-13-01
+        - name: p04
+          in: query
+          type: string
+          format: date-time
+          default: '1963-13-19T08:30:06.283185Z'
+        - name: p05
+          in: query
+          type: string
+          format: duration
+          default: 'three weeks'
+        - name: p06
+          in: query
+          type: string
+          format: email
+          default: 'joe.bloggs-example.com'
+        - name: p07
+          in: query
+          type: string
+          format: hexcolor
+          default: 'xFFFFFF'
+        - name: p08
+          in: query
+          type: string
+          format: hostname
+          default: 'not_a_valid_hostname'
+        - name: p09
+          in: query
+          type: string
+          format: ipv4
+          default: '192.168.0.256'
+        - name: p10
+          in: query
+          type: string
+          format: ipv6
+          default:  'o::1'
+        - name: p11
+          in: query
+          type: string
+          format: isbn
+          default: 'abc-0321751043'
+        - name: p12
+          in: query
+          type: string
+          format: isbn10
+          default: 'abc-0321751043'
+        - name: p13
+          in: query
+          type: string
+          format: isbn13
+          default: '978|3401013190'
+        - name: p14
+          in: query
+          type: string
+          format: mac
+          default: '01:02:03:04:05:06:07'
+        - name: p15
+          in: query
+          type: string
+          format: bsonobjectid
+          default: 'x07f1f77bcf86cd799439011'
+        - name: p16
+          in: query
+          type: string
+          format: password
+          default: 0
+        - name: p17
+          in: query
+          type: string
+          format: rgbcolor
+          default: 'rgb(100,100)'
+        - name: p18
+          in: query
+          type: string
+          format: ssn
+          default: '111-11111'
+        - name: p19
+          in: query
+          type: string
+          format: uri
+          default: 'httz://foo.bar/?baz=qux#quux'
+        - name: p20
+          in: query
+          type: string
+          format: uuid
+          default: 'a8098c1a+f86e+11da+bd1a+00112444be1e'
+        - name: p21
+          in: query
+          type: string
+          format: uuid3
+          default: 'bcd02e22+68f0+3046+a512+327cca9def8f'
+        - name: p22
+          in: query
+          type: string
+          format: uuid4
+          default: '025b0d74+00a2+4048+bf57+227c5111bb34'
+        - name: p23
+          in: query
+          type: string
+          format: uuid5
+          default: '886313e1+3b8a+5372+9b90+0c9aee199e5d'
+        - name: n01
+          in: query
+          type: number
+          format: float
+          default: abc
+        - name: n02
+          in: query
+          type: number
+          format: double
+          default: 100.99
+        - name: n03
+          in: query
+          type: integer
+          format: int32
+          default: -12.05
+        - name: n04
+          in: query
+          type: integer
+          format: int64
+          default: 20.05
+        - name: n05
+          in: query
+          type: integer
+          format: uint32
+          default: -20
+        - name: n06
+          in: query
+          type: integer
+          format: uint64
+          default: -30
+      responses:
+        200:
+          description: 'response exercising formats'
+          schema:
+            $ref: '#/definitions/allformats-bad'
+ 
+  /fixture/body:
+    post:
+      operationId: op3
+      parameters:
+        - name: allformat
+          in: body
+          schema:
+            $ref: '#/definitions/allformats'
+      responses:
+        200:
+          description: 'response exercising formats'
+          # TODO: check format in headers
+          schema:
+            $ref: '#/definitions/allformats'
+  /fixture/file:
+    post:
+      operationId: op4
+      consumes: 
+      - multipart/form-data
+      parameters:
+        - name: f01
+          in: formData
+          type: file
+          required: true
+        - name: f02
+          in: formData
+          type: file
+          required: false
+      responses:
+        200:
+          description: 'response exercising formats'
+
+definitions:
+  allformats:
+    type: object
+    properties:
+      prop01:
+        type: string
+        format: byte
+        default: 'ZWxpemFiZXRocG9zZXk='
+      prop02:
+        type: string
+        format: creditcard
+        default: '4111-1111-1111-1111'
+      prop03:
+        type: string
+        format: date
+        default: 1970-01-01
+      prop04:
+        type: string
+        format: date-time
+        default: '1963-06-19T08:30:06.283185Z'
+      prop05:
+        type: string
+        format: duration
+        default: '3 weeks'
+      prop06:
+        type: string
+        format: email
+        default: 'joe.bloggs@example.com'
+      prop07:
+        type: string
+        format: hexcolor
+        default: '#FFFFFF'
+      prop08:
+        type: string
+        format: hostname
+        default: 'www.example.com'
+      prop09:
+        type: string
+        format: ipv4
+        default: '192.168.0.1'
+      prop10:
+        type: string
+        format: ipv6
+        default:  '::1'
+      prop11:
+        type: string
+        format: isbn
+        default: '0321751043'
+      prop12:
+        type: string
+        format: isbn10
+        default: '0321751043'
+      prop13:
+        type: string
+        format: isbn13
+        default: '978 3401013190'
+      prop14:
+        type: string
+        format: mac
+        default: '01:02:03:04:05:06'
+      prop15:
+        type: string
+        format: bsonobjectid
+        default: '507f1f77bcf86cd799439011'
+      prop16:
+        type: string
+        format: password
+        default: 'secret'
+      prop17:
+        type: string
+        format: rgbcolor
+        default: 'rgb(100,100,100)'
+      prop18:
+        type: string
+        format: ssn
+        default: '111-11-1111'
+      prop19:
+        type: string
+        format: uri
+        default: 'http://foo.bar/?baz=qux#quux'
+      prop20:
+        type: string
+        format: uuid
+        default: 'a8098c1a-f86e-11da-bd1a-00112444be1e'
+      prop21:
+        type: string
+        format: uuid3
+        default: 'bcd02e22-68f0-3046-a512-327cca9def8f'
+      prop22:
+        type: string
+        format: uuid4
+        default: '025b0d74-00a2-4048-bf57-227c5111bb34'
+      prop23:
+        type: string
+        format: uuid5
+        default: '886313e1-3b8a-5372-9b90-0c9aee199e5d'
+      propn01:
+        type: number
+        format: float
+        default: 10.01
+      propn02:
+        type: number
+        format: double
+        default: 100.99
+      propn03:
+        type: integer
+        format: int32
+        default: -12
+      propn04:
+        type: integer
+        format: int64
+        default: 20
+      propn05:
+        type: integer
+        format: uint32
+        default: 20
+      propn06:
+        type: integer
+        format: uint64
+        default: 30
+  allformats-bad:
+    type: object
+    properties:
+      prop01:
+        type: string
+        format: byte
+        default: 'ZWxpemFiZXRocG9zZXk'
+      prop02:
+        type: string
+        format: creditcard
+        default: '4111-1111-1111-111K'
+      prop03:
+        type: string
+        format: date
+        default: 1970-01-32
+      prop04:
+        type: string
+        format: date-time
+        default: '1963-06-19T99:30:06.283185Z'
+      prop05:
+        type: string
+        format: duration
+        default: 'weeks'
+      prop06:
+        type: string
+        format: email
+        default: 'joe.bloggs-example.com'
+      prop07:
+        type: string
+        format: hexcolor
+        default: 1
+      prop08:
+        type: string
+        format: hostname
+        default: '---invalid-hostname---'
+      prop09:
+        type: string
+        format: ipv4
+        default: '192.2.0.1.45'
+      prop10:
+        type: string
+        format: ipv6
+        default:  'x::1'
+      prop11:
+        type: string
+        format: isbn
+        default: 'X0321751043'
+      prop12:
+        type: string
+        format: isbn10
+        default: 'X0321751043'
+      prop13:
+        type: string
+        format: isbn13
+        default: 'X978 3401013190'
+      prop14:
+        type: string
+        format: mac
+        default: 'X1:02:03:04:05:06'
+      prop15:
+        type: string
+        format: bsonobjectid
+        default: 'X507f1f77bcf86cd799439011'
+      prop16:
+        type: string
+        format: password
+        default: 10
+      prop17:
+        type: string
+        format: rgbcolor
+        default: 'gb(100,100,100)'
+      prop18:
+        type: string
+        format: ssn
+        default: 'Z111-11-1111'
+      prop19:
+        type: string
+        format: uri
+        default: 'xttp://foo.bar/?baz=qux#quux'
+      prop20:
+        type: string
+        format: uuid
+        default: 'a8098c1a+f86e+11da+bd1a+00112444be1e'
+      prop21:
+        type: string
+        format: uuid3
+        default: 'bcd02e22+68f0+3046+a512+327cca9def8f'
+      prop22:
+        type: string
+        format: uuid4
+        default: '025b0d74+00a2+4048+bf57+227c5111bb34'
+      prop23:
+        type: string
+        format: uuid5
+        default: '886313e1+3b8a+5372+9b90+0c9aee199e5d'
+      propn01:
+        type: number
+        format: float
+        default: abc
+      propn02:
+        type: number
+        format: double
+        default: abc
+      propn03:
+        type: integer
+        format: int32
+        default: -12.05
+      propn04:
+        type: integer
+        format: int64
+        default: 20.99
+      propn05:
+        type: integer
+        format: uint32
+        default: 20.05
+      propn06:
+        type: integer
+        format: uint64
+        default: 30.05

--- a/fixtures/validation/fixture-bad-response.yaml
+++ b/fixtures/validation/fixture-bad-response.yaml
@@ -1,0 +1,31 @@
+---
+swagger: '2.0'
+info:
+  title: checking $ref siblings in response
+  version: '1.0'
+  description: |
+    This one checks that wrong response declaraion with $ref sibling
+    is correcly handled and reported
+
+produces:
+  - application/json
+paths:
+  /fixture:
+    get:
+      operationId: op1
+      parameters:
+        - name: myid
+          in: body
+          schema:
+            $ref: '#/definitions/myId'
+      responses:
+        200:
+          description: 'response with $ref sibling'
+          schema:
+          $ref: '#/definitions/someIds'
+
+definitions:
+  myId:
+    type: string
+  someIds:
+    type: integer

--- a/formats.go
+++ b/formats.go
@@ -60,6 +60,7 @@ func (f *formatValidator) Applies(source interface{}, kind reflect.Kind) bool {
 
 func (f *formatValidator) Validate(val interface{}) *Result {
 	result := new(Result)
+	debugLog("validating \"%v\" against format: %s", val, f.Format)
 
 	if err := FormatOf(f.Path, f.In, f.Format, val.(string), f.KnownFormats); err != nil {
 		result.AddErrors(err)

--- a/messages_test.go
+++ b/messages_test.go
@@ -439,8 +439,8 @@ func verifyLoadErrors(t *testing.T, err error, expectedMessages []ExpectedMessag
 
 // Test unitary fixture for dev and bug fixing
 func Test_SingleFixture(t *testing.T) {
-	t.SkipNow()
-	path := "fixtures/validation/gentest3.yaml"
+	//t.SkipNow()
+	path := "fixtures/validation/fixture-bad-response.yaml"
 	doc, err := loads.Spec(path)
 	if assert.NoError(t, err) {
 		validator := NewSpecValidator(doc.Schema(), strfmt.Default)

--- a/schema.go
+++ b/schema.go
@@ -116,7 +116,12 @@ func (s *SchemaValidator) Validate(data interface{}) *Result {
 		kind = tpe.Kind()
 	}
 	d := data
+
 	if kind == reflect.Struct {
+		// NOTE: since reflect retrieves the true nature of types
+		// this means that all strfmt types passed here (e.g. strfmt.Datetime, etc..)
+		// are converted here to strings, and structs are systematically converted
+		// to map[string]interface{}.
 		d = swag.ToDynamicJSON(data)
 	}
 

--- a/spec_messages.go
+++ b/spec_messages.go
@@ -107,6 +107,10 @@ const (
 	// InvalidReferenceError indicates that a $ref property could not be resolved
 	InvalidReferenceError = "invalid ref %q"
 
+	// InvalidResponseDefinitionAsSchemaError indicates an error detected on a response definition, which was mistaken with a schema definition.
+	// Most likely, this situation is encountered whenever a $ref has been added as a sibling of the response definition.
+	InvalidResponseDefinitionAsSchemaError = "invalid definition as Schema for response %s in %s"
+
 	// MultipleBodyParamError indicates that an operation specifies multiple parameter with in: body
 	MultipleBodyParamError = "operation %q has more than 1 body param: %v"
 
@@ -336,6 +340,9 @@ func invalidParameterDefinitionMsg(path, method, operationID string) errors.Erro
 }
 func invalidParameterDefinitionAsSchemaMsg(path, method, operationID string) errors.Error {
 	return errors.New(errors.CompositeErrorCode, InvalidParameterDefinitionAsSchemaError, path, method, operationID)
+}
+func invalidResponseDefinitionAsSchemaMsg(path, method string) errors.Error {
+	return errors.New(errors.CompositeErrorCode, InvalidResponseDefinitionAsSchemaError, path, method)
 }
 func someParametersBrokenMsg(path, method, operationID string) errors.Error {
 	return errors.New(errors.CompositeErrorCode, SomeParametersBrokenError, path, method, operationID)

--- a/type.go
+++ b/type.go
@@ -33,31 +33,50 @@ type typeValidator struct {
 }
 
 func (t *typeValidator) schemaInfoForType(data interface{}) (string, string) {
-	// internal type to JSON type / swagger 2.0 format,
-	// as per https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md
+	// internal type to JSON type with swagger 2.0 format (with go-openapi/strfmt extensions),
+	// see https://github.com/go-openapi/strfmt/blob/master/README.md
 	// TODO: this switch really is some sort of reverse lookup for formats. It should be provided by strfmt.
 	switch data.(type) {
-	case []byte:
+	case []byte, strfmt.Base64, *strfmt.Base64:
 		return "string", "byte"
+	case strfmt.CreditCard, *strfmt.CreditCard:
+		return "string", "creditcard"
 	case strfmt.Date, *strfmt.Date:
 		return "string", "date"
 	case strfmt.DateTime, *strfmt.DateTime:
-		// TODO: spec says date-time, so says JSON schema. strfmt says otherwise
-		return "string", "datetime"
+		return "string", "date-time"
+	case strfmt.Duration, *strfmt.Duration:
+		return "string", "duration"
 	case runtime.File, *runtime.File:
 		return "file", ""
-	case strfmt.URI, *strfmt.URI:
-		return "string", "uri"
 	case strfmt.Email, *strfmt.Email:
 		return "string", "email"
+	case strfmt.HexColor, *strfmt.HexColor:
+		return "string", "hexcolor"
 	case strfmt.Hostname, *strfmt.Hostname:
 		return "string", "hostname"
 	case strfmt.IPv4, *strfmt.IPv4:
 		return "string", "ipv4"
 	case strfmt.IPv6, *strfmt.IPv6:
 		return "string", "ipv6"
+	case strfmt.ISBN, *strfmt.ISBN:
+		return "string", "isbn"
+	case strfmt.ISBN10, *strfmt.ISBN10:
+		return "string", "isbn10"
+	case strfmt.ISBN13, *strfmt.ISBN13:
+		return "string", "isbn13"
 	case strfmt.MAC, *strfmt.MAC:
 		return "string", "mac"
+	case strfmt.ObjectId, *strfmt.ObjectId:
+		return "string", "bsonobjectid"
+	case strfmt.Password, *strfmt.Password:
+		return "string", "password"
+	case strfmt.RGBColor, *strfmt.RGBColor:
+		return "string", "rgbcolor"
+	case strfmt.SSN, *strfmt.SSN:
+		return "string", "ssn"
+	case strfmt.URI, *strfmt.URI:
+		return "string", "uri"
 	case strfmt.UUID, *strfmt.UUID:
 		return "string", "uuid"
 	case strfmt.UUID3, *strfmt.UUID3:
@@ -66,22 +85,7 @@ func (t *typeValidator) schemaInfoForType(data interface{}) (string, string) {
 		return "string", "uuid4"
 	case strfmt.UUID5, *strfmt.UUID5:
 		return "string", "uuid5"
-	case strfmt.ISBN, *strfmt.ISBN:
-		return "string", "isbn"
-	case strfmt.ISBN10, *strfmt.ISBN10:
-		return "string", "isbn10"
-	case strfmt.ISBN13, *strfmt.ISBN13:
-		return "string", "isbn13"
-	case strfmt.CreditCard, *strfmt.CreditCard:
-		return "string", "creditcard"
-	case strfmt.SSN, *strfmt.SSN:
-		return "string", "ssn"
-	case strfmt.HexColor, *strfmt.HexColor:
-		return "string", "hexcolor"
-	case strfmt.RGBColor, *strfmt.RGBColor:
-		return "string", "rgbcolor"
-	// TODO: missing password
-	// TODO: missing binary
+	// TODO: missing binary (io.ReadCloser)
 	// TODO: missing json.Number
 	default:
 		val := reflect.ValueOf(data)
@@ -122,6 +126,7 @@ func (t *typeValidator) SetPath(path string) {
 }
 
 func (t *typeValidator) Applies(source interface{}, kind reflect.Kind) bool {
+	// typeValidator applies to Schema, Parameter and Header objects
 	stpe := reflect.TypeOf(source)
 	r := (len(t.Type) > 0 || t.Format != "") && (stpe == specSchemaType || stpe == specParameterType || stpe == specHeaderType)
 	debugLog("type validator for %q applies %t for %T (kind: %v)\n", t.Path, r, source, kind)
@@ -132,6 +137,7 @@ func (t *typeValidator) Validate(data interface{}) *Result {
 	result := new(Result)
 	result.Inc()
 	if data == nil || reflect.DeepEqual(reflect.Zero(reflect.TypeOf(data)), reflect.ValueOf(data)) {
+		// nil or zero value for the passed structure require Type: null
 		if len(t.Type) > 0 && !t.Type.Contains("null") { // TODO: if a property is not required it also passes this
 			return errorHelp.sErr(errors.InvalidType(t.Path, t.In, strings.Join(t.Type, ","), "null"))
 		}
@@ -142,9 +148,14 @@ func (t *typeValidator) Validate(data interface{}) *Result {
 	val := reflect.Indirect(reflect.ValueOf(data))
 	kind := val.Kind()
 
+	// infer schema type (JSON) and format from passed data type
 	schType, format := t.schemaInfoForType(data)
 
-	debugLog("path:", t.Path, "schType:", schType, "format:", format, "expType:", t.Type, "expFmt:", t.Format, "kind:", val.Kind().String())
+	debugLog("path: %s, schType: %s,  format: %s, expType: %s, expFmt: %s, kind: %s", t.Path, schType, format, t.Type, t.Format, val.Kind().String())
+
+	// check numerical types
+	// TODO: check unsigned ints
+	// TODO: check json.Number (see schema.go)
 	isLowerInt := t.Format == "int64" && format == "int32"
 	isLowerFloat := t.Format == "float64" && format == "float32"
 	isFloatInt := schType == "number" && swag.IsFloat64AJSONInteger(val.Float()) && t.Type.Contains("integer")
@@ -154,6 +165,7 @@ func (t *typeValidator) Validate(data interface{}) *Result {
 		// TODO: test case
 		return errorHelp.sErr(errors.InvalidType(t.Path, t.In, t.Format, format))
 	}
+
 	if !(t.Type.Contains("number") || t.Type.Contains("integer")) && t.Format != "" && (kind == reflect.String || kind == reflect.Slice) {
 		return result
 	}

--- a/type_test.go
+++ b/type_test.go
@@ -15,6 +15,7 @@
 package validate
 
 import (
+	"io"
 	"testing"
 	"time"
 
@@ -44,7 +45,7 @@ func TestType_schemaInfoForType(t *testing.T) {
 		expectedJSONType{
 			value:                 strfmt.NewDateTime(),
 			expectedJSONType:      "string",
-			expectedSwaggerFormat: "datetime",
+			expectedSwaggerFormat: "date-time",
 		},
 		expectedJSONType{
 			// TODO: this exception is really prone to errors: should alias runtime.File in strfmt
@@ -66,6 +67,11 @@ func TestType_schemaInfoForType(t *testing.T) {
 			value:                 strfmt.Hostname("www.github.com"),
 			expectedJSONType:      "string",
 			expectedSwaggerFormat: "hostname",
+		},
+		expectedJSONType{
+			value:                 strfmt.Password("secret"),
+			expectedJSONType:      "string",
+			expectedSwaggerFormat: "password",
 		},
 		expectedJSONType{
 			value:                 strfmt.IPv4("192.168.224.1"),
@@ -159,8 +165,9 @@ func TestType_schemaInfoForType(t *testing.T) {
 			expectedSwaggerFormat: "int32",
 		},
 		expectedJSONType{
-			value:                 uint16(12),
-			expectedJSONType:      "integer",
+			value:            uint16(12),
+			expectedJSONType: "integer",
+			// TODO: should be uint32
 			expectedSwaggerFormat: "int32",
 		},
 		expectedJSONType{
@@ -169,8 +176,9 @@ func TestType_schemaInfoForType(t *testing.T) {
 			expectedSwaggerFormat: "int32",
 		},
 		expectedJSONType{
-			value:                 uint32(12),
-			expectedJSONType:      "integer",
+			value:            uint32(12),
+			expectedJSONType: "integer",
+			// TODO: should be uint32
 			expectedSwaggerFormat: "int32",
 		},
 		expectedJSONType{
@@ -179,8 +187,9 @@ func TestType_schemaInfoForType(t *testing.T) {
 			expectedSwaggerFormat: "int64",
 		},
 		expectedJSONType{
-			value:                 uint(12),
-			expectedJSONType:      "integer",
+			value:            uint(12),
+			expectedJSONType: "integer",
+			// TODO: should be uint64
 			expectedSwaggerFormat: "int64",
 		},
 		expectedJSONType{
@@ -189,8 +198,9 @@ func TestType_schemaInfoForType(t *testing.T) {
 			expectedSwaggerFormat: "int64",
 		},
 		expectedJSONType{
-			value:                 uint64(12),
-			expectedJSONType:      "integer",
+			value:            uint64(12),
+			expectedJSONType: "integer",
+			// TODO: should be uint64
 			expectedSwaggerFormat: "int64",
 		},
 		expectedJSONType{
@@ -226,15 +236,28 @@ func TestType_schemaInfoForType(t *testing.T) {
 			expectedSwaggerFormat: "",
 		},
 		expectedJSONType{
+			// NOTE: Go array returns no JSON type
 			value:                 [4]int{1, 2, 4, 4},
 			expectedJSONType:      "",
 			expectedSwaggerFormat: "",
 		},
+		expectedJSONType{
+			value:                 strfmt.Base64("ZWxpemFiZXRocG9zZXk="),
+			expectedJSONType:      "string",
+			expectedSwaggerFormat: "byte",
+		},
+		expectedJSONType{
+			value:                 strfmt.Duration(0),
+			expectedJSONType:      "string",
+			expectedSwaggerFormat: "duration",
+		},
+		expectedJSONType{
+			value:                 strfmt.ObjectId("507f1f77bcf86cd799439011"),
+			expectedJSONType:      "string",
+			expectedSwaggerFormat: "bsonobjectid",
+		},
 		/*
-					TODO
-					B64:        Base64("ZWxpemFiZXRocG9zZXk="),
-					Pw:         Password("super secret stuff here"),
-			case reflect.Interface:
+			Test case for : case reflect.Interface:
 				// What to do here?
 				panic("dunno what to do here")
 		*/
@@ -250,4 +273,12 @@ func TestType_schemaInfoForType(t *testing.T) {
 		assert.Equal(t, x.expectedJSONType, jsonType)
 		assert.Equal(t, x.expectedSwaggerFormat, swaggerFormat)
 	}
+
+	// Check file declarations as io.ReadCloser are properly detected
+	myFile := runtime.File{}
+	var myReader io.ReadCloser
+	myReader = &myFile
+	jsonType, swaggerFormat := v.schemaInfoForType(myReader)
+	assert.Equal(t, "file", jsonType)
+	assert.Equal(t, "", swaggerFormat)
 }


### PR DESCRIPTION
- [x] Fixed panic case whenever a $ref is declared as sibling of response.
      Detect and report the case.
- [x] Sync'ed list of formats in type.go type switch
- [x] Added more tests on formats to extend json-schema test suite with all supported formats in strfmt
- [x] Added more tests on default values checks, with all formats in strfmt