### PR TITLE
Fixes #75

### DIFF
--- a/fixtures/validation/expected_messages.yaml
+++ b/fixtures/validation/expected_messages.yaml
@@ -366,6 +366,9 @@ fixture-342.yaml:
   - message: 'paths./get_main_object.get.parameters.$ref in body is a forbidden property'
     withContinueOnErrors: false
     isRegexp: false
+  - message: 'invalid definition for parameter sid in body in operation ""'
+    withContinueOnErrors: true
+    isRegexp: false
   - message: 'paths./get_main_object.get.parameters.in in body should be one of [header]'
     withContinueOnErrors: false
     isRegexp: false
@@ -378,23 +381,65 @@ fixture-342.yaml:
   - message: 'invalid ref "nowhere.yaml#/definitions/sample_info/properties/sid"'
     withContinueOnErrors: true
     isRegexp: false
-  - message: 'invalid definition as Schema for parameter sid in body in operation ""'
+  - message: 'invalid definition as Schema for parameter  in  in operation ""'
+    withContinueOnErrors: true
+    isRegexp: false
+  - message: 'invalid definition for parameter  in  in operation ""'
     withContinueOnErrors: true
     isRegexp: false
   - message: 'could not resolve reference in "/get_main_object".GET to $ref nowhere.yaml#/definitions/sample_info/properties/sid: open fixtures/validation/nowhere.yaml: no such file or directory'
     withContinueOnErrors: true
     isRegexp: false
-    #- message: 'resolved reference is not a parameter: "#/definitions/sample_info/properties/sid"'
-    #withContinueOnErrors: true
-    #isRegeexp: false
-    #- message: 'some parameters definitions are broken in "/get_main_object".GET. Cannot carry on full checks on parameters for operation'
-    #withContinueOnErrors: true
-    #isRegexp: false
+  - message: '"parameters.wrong" must validate one and only one schema (oneOf). Found none valid'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: 'parameters.wrong.theName in body is a forbidden property'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: 'parameters.wrong.theType in body is a forbidden property'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: 'parameters.wrong.name in body is required'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: 'parameters.wrong.in in body is required'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: 'parameters.wrong.type in body is required'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: '"parameters.notbetter" must validate one and only one schema (oneOf). Found none valid'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: 'parameters.notbetter.properties in body is a forbidden property'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: 'parameters.notbetter.type in body should be one of [string number boolean integer array]'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: 'parameters.notbetter.name in body is required'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: 'parameters.notbetter.in in body is required'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: '"parameters.stillnogood" must validate one and only one schema (oneOf). Found none valid'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: 'parameters.stillnogood.name in body is required'
+    withContinueOnErrors: false
+    isRegexp: false
+  - message: 'parameters.stillnogood.in in body is required'
+    withContinueOnErrors: false
+    isRegexp: false
   expectedWarnings:
   - message: 'definition "#/definitions/sample_info" is not used anywhere'
     withContinueOnErrors: true
     isRegexp: false
   - message: $ref property should have no sibling in "".sid
+    withContinueOnErrors: true
+    isRegexp: false
+  - message: $ref property should have no sibling in "".
     withContinueOnErrors: true
     isRegexp: false
 fixture-581-good-numbers.yaml:

--- a/fixtures/validation/expected_messages.yaml
+++ b/fixtures/validation/expected_messages.yaml
@@ -375,15 +375,21 @@ fixture-342.yaml:
   - message: '"paths./get_main_object.get.parameters" must validate one and only one schema (oneOf). Found none valid'
     withContinueOnErrors: false
     isRegexp: false
+  - message: 'invalid ref "nowhere.yaml#/definitions/sample_info/properties/sid"'
+    withContinueOnErrors: true
+    isRegexp: false
   - message: 'invalid definition as Schema for parameter sid in body in operation ""'
     withContinueOnErrors: true
     isRegexp: false
-  - message: 'resolved reference is not a parameter: "#/definitions/sample_info/properties/sid"'
-    withContinueOnErrors: true
-    isRegeexp: false
-  - message: 'some parameters definitions are broken in "/get_main_object".GET. Cannot carry on full checks on parameters for operation'
+  - message: 'could not resolve reference in "/get_main_object".GET to $ref nowhere.yaml#/definitions/sample_info/properties/sid: open fixtures/validation/nowhere.yaml: no such file or directory'
     withContinueOnErrors: true
     isRegexp: false
+    #- message: 'resolved reference is not a parameter: "#/definitions/sample_info/properties/sid"'
+    #withContinueOnErrors: true
+    #isRegeexp: false
+    #- message: 'some parameters definitions are broken in "/get_main_object".GET. Cannot carry on full checks on parameters for operation'
+    #withContinueOnErrors: true
+    #isRegexp: false
   expectedWarnings:
   - message: 'definition "#/definitions/sample_info" is not used anywhere'
     withContinueOnErrors: true
@@ -592,7 +598,7 @@ fixture-859-good.yaml:
 fixture-859.yaml:
   comment: 'Issue#859: clear message on unresolved $ref. First scenario for messages
     Supplement for items, arrays and other nested structures in fixture-859-2.yaml'
-  todo: would love to have all missing references in one shot. This works only for parameters as for now.
+  todo: would love to have all missing references in one shot.
   expectedLoadError: false
   expectedValid: false
   expectedMessages:
@@ -605,18 +611,21 @@ fixture-859.yaml:
   - message: 'some references could not be resolved in spec\. First found: object has no key ".*"'
     withContinueOnErrors: true
     isRegexp: true
-  - message: 'invalid reference: "#/parameters/rateLimit"'
-    withContinueOnErrors: true
-    isRegexp: true
+    #- message: 'invalid reference: "#/parameters/rateLimit"'
+    #withContinueOnErrors: true
+    #isRegexp: true
   - message: 'could not resolve reference in "/".GET to $ref #/parameters/rateLimit: object has no key "rateLimit"'
     withContinueOnErrors: true
     isRegexp: false
-  - message: some parameters definitions are broken in "/".POST. Cannot carry on full checks on parameters for operation
+  - message: 'could not resolve reference in / to $ref : object has no key "record"'
     withContinueOnErrors: true
     isRegexp: false
-  - message: some parameters definitions are broken in "/".GET. Cannot carry on full checks on parameters for operation
-    withContinueOnErrors: true
-    isRegexp: false
+    #- message: some parameters definitions are broken in "/".POST. Cannot carry on full checks on parameters for operation
+    #withContinueOnErrors: true
+    #isRegexp: false
+    #- message: some parameters definitions are broken in "/".GET. Cannot carry on full checks on parameters for operation
+    #withContinueOnErrors: true
+    #isRegexp: false
   - message: 'could not resolve reference in "/".POST to $ref #/parameters/rateLimit: object has no key "rateLimit"'
     withContinueOnErrors: true
     isRegexp: false
@@ -1293,11 +1302,7 @@ fixture-bad-response.yaml:
   expectedMessages:
   - message: '"paths./fixture.get.responses.200" must validate one and only one schema (oneOf). Found none valid'
   - message: 'paths./fixture.get.responses.200.$ref in body is a forbidden property'
-  - message: 'invalid definition as Schema for response /fixture in responses'
-    withContinueOnErrors: true
   expectedWarnings:
-  - message: '$ref property should have no sibling in "responses"./fixture'
-    withContinueOnErrors: true
   - message: 'definition "#/definitions/someIds" is not used anywhere'
     withContinueOnErrors: true
 

--- a/fixtures/validation/fixture-342.yaml
+++ b/fixtures/validation/fixture-342.yaml
@@ -26,6 +26,9 @@ paths:
           in: query
           required: true
           $ref: "#/definitions/sample_info/properties/sid"  # <-- error: a whole schema replaces the parameter
+        - $ref: "#/parameters/wrong"  # <-- error: wrong param props
+        - $ref: "#/parameters/notbetter"  # <-- error: wrong param schema
+        - $ref: "#/parameters/stillnogood"  # <-- error: wrong param schema
         - name: pquery2
           in: query
           required: true
@@ -37,6 +40,22 @@ paths:
       responses:
         '200':
 
+parameters:
+  wrong:
+    theName: wrongNameProperty
+    theType: wrongTypePropery
+  notbetter:
+    type: object
+    properties:
+      whenDidThatHappen:
+        type: string
+        format: date
+  stillnogood:
+    schema:
+      type: object
+      properties:
+        aintnogood:
+          type: integer
 definitions:
   sample_info:
     type: object

--- a/fixtures/validation/fixture-342.yaml
+++ b/fixtures/validation/fixture-342.yaml
@@ -2,7 +2,9 @@ swagger: '2.0'
 info:
   title: issue-342
   description: |
-    A spec which triggers a panic because of invalid type assertion on parameters
+    Original issue: a spec which triggers a panic because of invalid type assertion on parameters.
+    Specifically, this tests how validation carries on when references returns an unexpected object.
+    This may happen for parameters and responses and should be accurately reported.
   version: 0.0.1
   license:
     name: MIT
@@ -20,11 +22,18 @@ paths:
       tags:
         - maindata
       parameters:
-        # This one is interesting: a whole schema replaces the parameter
+        - name: pquery1
+          in: query
+          required: true
+          $ref: "#/definitions/sample_info/properties/sid"  # <-- error: a whole schema replaces the parameter
+        - name: pquery2
+          in: query
+          required: true
+          $ref: "nowhere.yaml#/definitions/sample_info/properties/sid"  # <-- error: expand ref error
         - name: sid
           in: body
           required: true
-          $ref: "#/definitions/sample_info/properties/sid"  
+          $ref: "#/definitions/sample_info/properties/sid"  # <-- error: a whole schema replaces the parameter
       responses:
         '200':
 
@@ -34,4 +43,5 @@ definitions:
     properties:
       sid:
         type: string
+        format: uuid
 

--- a/fixtures/validation/fixture-859.yaml
+++ b/fixtures/validation/fixture-859.yaml
@@ -9,7 +9,6 @@ paths:
       parameters:
         # error
         - $ref: "#/parameters/rateLimit"
-        # error: $ref sibling
         - name: myparam
           in: query
           type: string
@@ -18,27 +17,22 @@ paths:
           description: "Success"
     get:
       parameters:
-        # error
-        - $ref: "#/parameters/rateLimit"
-        # error $ref sibling
+        - $ref: "#/parameters/rateLimit"        #  <-- error: mispelled reference cannot resolve
         - name: myparam
           in: query
           schema:
-            # error
-            $ref: '#/definitions/myparam'
+            $ref: '#/definitions/myparam' # <- error : mispelled reference cannot resolve
       responses:
         default:
           description: the record
           schema:
-            # error
-            $ref: "#/definitions/record"
+            $ref: "#/definitions/record" # <- error : mispelled reference cannot resolve
         404:
           $ref: "#/responses/notFound"
         200:
           description: "Success"
           schema:
-            # error
-            $ref: "#definitions/myoutput"
+            $ref: "#definitions/myoutput" # <- error : mispelled reference cannot resolve
 
 parameters:
   rateLimits:
@@ -51,8 +45,7 @@ responses:
   notFound:
     description: Not found
     schema:
-      # error
-      $ref: "#/definitions/record"
+      $ref: "#/definitions/record"  # <- error : mispelled reference cannot resolve
 
 definitions:
   records:

--- a/helpers.go
+++ b/helpers.go
@@ -148,70 +148,80 @@ type paramHelper struct {
 }
 
 func (h *paramHelper) safeExpandedParamsFor(path, method, operationID string, res *Result, s *SpecValidator) (params []spec.Parameter) {
-	for _, ppr := range s.analyzer.SafeParamsFor(method, path,
-		func(p spec.Parameter, err error) bool {
-			res.AddErrors(someParametersBrokenMsg(path, method, operationID))
-			// original error from analyzer
-			res.AddErrors(err)
-			return true
-		}) {
-		pr, red := h.resolveParam(path, method, operationID, ppr, s)
-		if red.HasErrors() { // Safeguard
-			// NOTE: it looks like the new spec.Ref.GetPointer() method expands the full tree, so this code is no more reachable
+	operation, ok := s.analyzer.OperationFor(method, path)
+	if ok {
+		// expand parameters first if necessary
+		resolvedParams := []spec.Parameter{}
+		for _, ppr := range operation.Parameters {
+			resolvedParam, red := h.resolveParam(path, method, operationID, &ppr, s)
 			res.Merge(red)
-			if red.HasErrors() && !s.Options.ContinueOnErrors {
-				break
+			if resolvedParam != nil {
+				resolvedParams = append(resolvedParams, *resolvedParam)
 			}
-			continue
 		}
-		params = append(params, pr)
+		// remove params with invalid expansion from slice
+		operation.Parameters = resolvedParams
+
+		for _, ppr := range s.analyzer.SafeParamsFor(method, path,
+			func(p spec.Parameter, err error) bool {
+				// since params have already been expanded, there are few causes for error
+				res.AddErrors(someParametersBrokenMsg(path, method, operationID))
+				// original error from analyzer
+				res.AddErrors(err)
+				return true
+			}) {
+			pr, red := h.resolveParam(path, method, operationID, &ppr, s)
+			if red.HasErrors() { // Safeguard
+				// NOTE: it looks like the new spec.Ref.GetPointer() method expands the full tree, so this code is no more reachable
+				res.Merge(red)
+				if red.HasErrors() && !s.Options.ContinueOnErrors {
+					break
+				}
+				continue
+			}
+			params = append(params, *pr)
+		}
 	}
 	return
 }
 
-func (h *paramHelper) resolveParam(path, method, operationID string, ppr spec.Parameter, s *SpecValidator) (spec.Parameter, *Result) {
-	// Resolve references with any depth for parameter
-	// NOTE: the only difference with what analysis does is in the "for": analysis SafeParamsFor() stops at first ref.
+func (h *paramHelper) resolveParam(path, method, operationID string, param *spec.Parameter, s *SpecValidator) (*spec.Parameter, *Result) {
+	// Expand parameter with $ref if needed
 	res := new(Result)
-	pr := ppr
-	sw := s.spec.Spec()
 
-	for pr.Ref.String() != "" {
-		obj, _, err := pr.Ref.GetPointer().Get(sw)
+	if param.Ref.String() != "" {
+		err := spec.ExpandParameter(param, s.spec.SpecFilePath())
 		if err != nil { // Safeguard
 			// NOTE: we may enter enter here when the whole parameter is an unresolved $ref
 			refPath := strings.Join([]string{"\"" + path + "\"", method}, ".")
-			errorHelp.addPointerError(res, err, pr.Ref.String(), refPath)
-			pr = spec.Parameter{}
-		} else {
-			if checkedObj, ok := h.checkedParamAssertion(obj, pr.Name, pr.In, operationID, res); ok {
-				pr = checkedObj
-			} else {
-				pr = spec.Parameter{}
-			}
+			errorHelp.addPointerError(res, err, param.Ref.String(), refPath)
+			return nil, res
 		}
+		res.Merge(h.checkExpandedParam(param, param.Name, param.In, operationID))
 	}
-	return pr, res
+	return param, res
 }
 
-func (h *paramHelper) checkedParamAssertion(obj interface{}, path, in, operation string, res *Result) (spec.Parameter, bool) {
-	// Secure parameter type assertion and try to explain failure
-	if checkedObj, ok := obj.(spec.Parameter); ok {
-		return checkedObj, true
-	}
+func (h *paramHelper) checkExpandedParam(pr *spec.Parameter, path, in, operation string) *Result {
+	// Secure parameter structure after $ref resolution
+	res := new(Result)
+	simpleZero := spec.SimpleSchema{}
 	// Try to explain why... best guess
-	if _, ok := obj.(spec.Schema); ok {
+	if pr.In == "body" && pr.SimpleSchema != simpleZero {
 		// Most likely, a $ref with a sibling is an unwanted situation: in itself this is a warning...
 		res.AddWarnings(refShouldNotHaveSiblingsMsg(path, operation))
+		res.AddErrors(invalidParameterDefinitionAsSchemaMsg(path, in, operation))
+	} else if pr.In != "body" && pr.Schema != nil {
 		// but we detect it because of the following error:
 		// schema took over Parameter for an unexplained reason
+		// TODO: distinguish situation from previous one with relevant message
+		res.AddWarnings(refShouldNotHaveSiblingsMsg(path, operation))
 		res.AddErrors(invalidParameterDefinitionAsSchemaMsg(path, in, operation))
-	} else { // Safeguard
-		// NOTE: the only known case for this error is $ref expansion replaced parameter by a Schema
-		// Here, another structure replaced spec.Parameter. We should not be able to enter there. Croaks a generic error.
+	} else if (pr.In == "body" && pr.Schema == nil) || (pr.In != "body" && pr.SimpleSchema == simpleZero) { // Safeguard
+		// Other unexpected mishaps
 		res.AddErrors(invalidParameterDefinitionMsg(path, in, operation))
 	}
-	return spec.Parameter{}, false
+	return res
 }
 
 type responseHelper struct {
@@ -219,27 +229,15 @@ type responseHelper struct {
 }
 
 func (r *responseHelper) expandResponseRef(response *spec.Response, path string, s *SpecValidator) (*spec.Response, *Result) {
-	// Recursively follows possible $ref's on responses
+	// Expand response with $ref if needed
 	res := new(Result)
-	for response.Ref.String() != "" {
-		obj, _, err := response.Ref.GetPointer().Get(s.spec.Spec())
+	if response.Ref.String() != "" {
+		err := spec.ExpandResponse(response, s.spec.SpecFilePath())
 		if err != nil { // Safeguard
 			// NOTE: we may enter here when the whole response is an unresolved $ref.
 			errorHelp.addPointerError(res, err, response.Ref.String(), path)
-			break
-		}
-		// NOTE: we may no expect type assertion to be guaranteed (like in the Parameter case):
-		// e.g: a $ref may override Response with Schema
-		nr, ok := obj.(spec.Response)
-		if !ok {
-			// Most likely, a $ref with a sibling is an unwanted situation: in itself this is a warning...
-			res.AddWarnings(refShouldNotHaveSiblingsMsg(path, "responses"))
-			// but we detect it because of the following error:
-			// schema took over Response for an unexplained reason
-			res.AddErrors(invalidResponseDefinitionAsSchemaMsg(path, "responses"))
 			return nil, res
 		}
-		response = &nr
 	}
 	return response, res
 }

--- a/messages_test.go
+++ b/messages_test.go
@@ -440,7 +440,7 @@ func verifyLoadErrors(t *testing.T, err error, expectedMessages []ExpectedMessag
 // Test unitary fixture for dev and bug fixing
 func Test_SingleFixture(t *testing.T) {
 	t.SkipNow()
-	path := filepath.Join("fixtures", "validation", "fixture-bad-response.yaml")
+	path := filepath.Join("fixtures", "validation", "fixture-342.yaml")
 	doc, err := loads.Spec(path)
 	if assert.NoError(t, err) {
 		validator := NewSpecValidator(doc.Schema(), strfmt.Default)

--- a/messages_test.go
+++ b/messages_test.go
@@ -440,7 +440,7 @@ func verifyLoadErrors(t *testing.T, err error, expectedMessages []ExpectedMessag
 // Test unitary fixture for dev and bug fixing
 func Test_SingleFixture(t *testing.T) {
 	t.SkipNow()
-	path := "fixtures/bugs/73/fixture-swagger-3.yaml"
+	path := filepath.Join("fixtures", "validation", "fixture-bad-response.yaml")
 	doc, err := loads.Spec(path)
 	if assert.NoError(t, err) {
 		validator := NewSpecValidator(doc.Schema(), strfmt.Default)

--- a/spec.go
+++ b/spec.go
@@ -654,10 +654,10 @@ func (s *SpecValidator) validateParameters() *Result {
 				var hasForm, hasBody bool
 
 				// Check parameters names uniqueness for operation
+				// TODO: should be done after param expansion
 				res.Merge(s.checkUniqueParams(path, method, op))
 
 				for _, pr := range paramHelp.safeExpandedParamsFor(path, method, op.ID, res, s) {
-
 					// Validate pattern regexp for parameters with a Pattern property
 					if _, err := compileRegexp(pr.Pattern); err != nil {
 						res.AddErrors(invalidPatternInParamMsg(op.ID, pr.Name, pr.Pattern))
@@ -754,10 +754,10 @@ func (s *SpecValidator) checkUniqueParams(path, method string, op *spec.Operatio
 	if op.Parameters != nil { // Safeguard
 		for _, ppr := range op.Parameters {
 			ok := false
-			pr, red := paramHelp.resolveParam(path, method, op.ID, ppr, s)
+			pr, red := paramHelp.resolveParam(path, method, op.ID, &ppr, s)
 			res.Merge(red)
 
-			if pr.Name != "" { // params with empty name does no participate the check
+			if pr != nil && pr.Name != "" { // params with empty name does no participate the check
 				key := fmt.Sprintf("%s#%s", pr.In, pr.Name)
 
 				if _, ok = pnames[key]; ok {

--- a/spec_messages.go
+++ b/spec_messages.go
@@ -341,9 +341,11 @@ func invalidParameterDefinitionMsg(path, method, operationID string) errors.Erro
 func invalidParameterDefinitionAsSchemaMsg(path, method, operationID string) errors.Error {
 	return errors.New(errors.CompositeErrorCode, InvalidParameterDefinitionAsSchemaError, path, method, operationID)
 }
-func invalidResponseDefinitionAsSchemaMsg(path, method string) errors.Error {
-	return errors.New(errors.CompositeErrorCode, InvalidResponseDefinitionAsSchemaError, path, method)
-}
+
+// disabled
+//func invalidResponseDefinitionAsSchemaMsg(path, method string) errors.Error {
+//	return errors.New(errors.CompositeErrorCode, InvalidResponseDefinitionAsSchemaError, path, method)
+//}
 func someParametersBrokenMsg(path, method, operationID string) errors.Error {
 	return errors.New(errors.CompositeErrorCode, SomeParametersBrokenError, path, method, operationID)
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -721,24 +721,21 @@ func TestSpec_Issue73(t *testing.T) {
 	if assert.NoError(t, err) {
 		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
 		res, _ := validator.Validate(doc)
-		assert.NotEmpty(t, res.Errors, " in fixture-swagger.yaml")
-		assert.Len(t, res.Errors, 1)
+		assert.Empty(t, res.Errors, " in fixture-swagger.yaml")
 	}
 
 	doc, err = loads.Spec(filepath.Join("fixtures", "bugs", "73", "fixture-swagger-2.yaml"))
 	if assert.NoError(t, err) {
 		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
 		res, _ := validator.Validate(doc)
-		assert.NotEmpty(t, res.Errors, "in fixture-swagger-2.yaml")
-		assert.Len(t, res.Errors, 3)
+		assert.Empty(t, res.Errors, "in fixture-swagger-2.yaml")
 	}
 
 	doc, err = loads.Spec(filepath.Join("fixtures", "bugs", "73", "fixture-swagger-3.yaml"))
 	if assert.NoError(t, err) {
 		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
 		res, _ := validator.Validate(doc)
-		assert.NotEmpty(t, res.Errors, "in fixture-swagger-3.yaml")
-		assert.Len(t, res.Errors, 1)
+		assert.Empty(t, res.Errors, "in fixture-swagger-3.yaml")
 	}
 
 	doc, err = loads.Spec(filepath.Join("fixtures", "bugs", "73", "fixture-swagger-good.yaml"))


### PR DESCRIPTION
Fixes #75

- Overhauled $ref resolution for parameters and responses
- Adapted further checking on invalid input (e.g. $ref sibling) to keep informative messages

Will fix go-swagger/go-swagger#1406 after vendor update.
