### PR TITLE
Allow typed slices via reflection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 - go get -u github.com/go-openapi/loads
 - go get -u github.com/go-openapi/strfmt
 - go get -u github.com/go-openapi/runtime
+- go get -u github.com/docker/go-units
 env:
 # Short test suite, with race testing
 - TEST_COMMAND="go test -v -race -covermode=atomic"
@@ -25,6 +26,8 @@ env:
 - TEST_COMMAND="go test -v -timeout=20m -cover -coverprofile=coverage.txt -args -enable-long"
 # go swagger non-reg as a separate env + exclude 1.8 for this
 - TEST_COMMAND="go test -v -timeout=30m -args -enable-go-swagger"
+# integration test with runtime repo
+- TEST_COMMAND="go test -v -timeout=30m github.com/go-openapi/runtime/..."
 # TODO(TEST): update json-schema-suite benchmark
 matrix:
   exclude:

--- a/post/defaulter.go
+++ b/post/defaulter.go
@@ -18,7 +18,8 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// ApplyDefaults applies defaults to data.
+// ApplyDefaults applies defaults to the underlying data of the result. The data must be a JSON
+// struct as returned by json.Unmarshal.
 func ApplyDefaults(r *validate.Result) {
 	fieldSchemata := r.FieldSchemata()
 	for key, schemata := range fieldSchemata {

--- a/post/prune.go
+++ b/post/prune.go
@@ -18,7 +18,8 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// Prune recursively removes all non-specified fields from the data.
+// Prune recursively removes all non-specified fields from the underlying data of the result.
+// The data must be a JSON struct as returned by json.Unmarshal.
 func Prune(r *validate.Result) {
 	prune(r.Data(), r)
 }

--- a/result.go
+++ b/result.go
@@ -82,7 +82,7 @@ func (fk *FieldKey) Field() string {
 }
 
 // NewItemKey returns a pair of a slice and index usable as a key of a map.
-func NewItemKey(slice []interface{}, i int) ItemKey {
+func NewItemKey(slice interface{}, i int) ItemKey {
 	return ItemKey{slice: reflect.ValueOf(slice), index: i}
 }
 
@@ -103,7 +103,7 @@ type fieldSchemata struct {
 }
 
 type itemSchemata struct {
-	slice    []interface{}
+	slice    reflect.Value
 	index    int
 	schemata schemata
 }
@@ -196,7 +196,7 @@ func (r *Result) mergeForField(obj map[string]interface{}, field string, other *
 }
 
 // mergeForSlice merges other into r, assigning other's root schemata to the given slice and index.
-func (r *Result) mergeForSlice(slice []interface{}, i int, other *Result) *Result {
+func (r *Result) mergeForSlice(slice reflect.Value, i int, other *Result) *Result {
 	if other == nil {
 		return r
 	}
@@ -204,7 +204,7 @@ func (r *Result) mergeForSlice(slice []interface{}, i int, other *Result) *Resul
 
 	if other.rootObjectSchemata.Len() > 0 {
 		if r.itemSchemata == nil {
-			r.itemSchemata = make([]itemSchemata, len(slice))
+			r.itemSchemata = make([]itemSchemata, slice.Len())
 		}
 		r.itemSchemata = append(r.itemSchemata, itemSchemata{
 			slice:    slice,
@@ -233,9 +233,9 @@ func (r *Result) addPropertySchemata(obj map[string]interface{}, fld string, sch
 
 // addSliceSchemata adds the given schemata for the slice and index.
 // The slice schemata might be reused. I.e. do not modify it after being added to a result.
-func (r *Result) addSliceSchemata(slice []interface{}, i int, schema *spec.Schema) {
+func (r *Result) addSliceSchemata(slice reflect.Value, i int, schema *spec.Schema) {
 	if r.itemSchemata == nil {
-		r.itemSchemata = make([]itemSchemata, 0, len(slice))
+		r.itemSchemata = make([]itemSchemata, 0, slice.Len())
 	}
 	r.itemSchemata = append(r.itemSchemata, itemSchemata{slice: slice, index: i, schemata: schemata{one: schema}})
 }

--- a/slice_validator.go
+++ b/slice_validator.go
@@ -57,7 +57,7 @@ func (s *schemaSliceValidator) Validate(data interface{}) *Result {
 		for i := 0; i < size; i++ {
 			validator.SetPath(fmt.Sprintf("%s.%d", s.Path, i))
 			value := val.Index(i)
-			result.mergeForSlice(data.([]interface{}), i, validator.Validate(value.Interface()))
+			result.mergeForSlice(val, i, validator.Validate(value.Interface()))
 		}
 	}
 
@@ -69,7 +69,7 @@ func (s *schemaSliceValidator) Validate(data interface{}) *Result {
 			if val.Len() <= i {
 				break
 			}
-			result.mergeForSlice(data.([]interface{}), int(i), validator.Validate(val.Index(i).Interface()))
+			result.mergeForSlice(val, int(i), validator.Validate(val.Index(i).Interface()))
 		}
 	}
 	if s.AdditionalItems != nil && itemsSize < size {
@@ -79,7 +79,7 @@ func (s *schemaSliceValidator) Validate(data interface{}) *Result {
 		if s.AdditionalItems.Schema != nil {
 			for i := itemsSize; i < size-itemsSize+1; i++ {
 				validator := NewSchemaValidator(s.AdditionalItems.Schema, s.Root, fmt.Sprintf("%s.%d", s.Path, i), s.KnownFormats)
-				result.mergeForSlice(data.([]interface{}), int(i), validator.Validate(val.Index(int(i)).Interface()))
+				result.mergeForSlice(val, int(i), validator.Validate(val.Index(int(i)).Interface()))
 			}
 		}
 	}


### PR DESCRIPTION
While the object validator assumes `map[string]interface{}` input, the slice validator is called from github.com/go-openapi/runtime/middleware with typed Golang slices.

This PR switches the result schema tracking to reflection in order to cope with typed slices as well.

Fixes the regression in https://github.com/go-openapi/validate/pull/81#issuecomment-381424409.

Replaces https://github.com/go-openapi/runtime/pull/99.