### PR TITLE
fix race in `reDict` when reading from regexp cache

### DIFF
--- a/rexp.go
+++ b/rexp.go
@@ -26,24 +26,24 @@ var (
 )
 
 func compileRegexp(pattern string) (*re.Regexp, error) {
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
 	// Save repeated regexp compilation
 	if reDict[pattern] != nil {
 		return reDict[pattern], nil
 	}
 	var err error
-	cacheMutex.Lock()
 	reDict[pattern], err = re.Compile(pattern)
-	cacheMutex.Unlock()
 	return reDict[pattern], err
 }
 
 func mustCompileRegexp(pattern string) *re.Regexp {
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
 	// Save repeated regexp compilation, with panic on error
 	if reDict[pattern] != nil {
 		return reDict[pattern]
 	}
-	defer cacheMutex.Unlock()
-	cacheMutex.Lock()
 	reDict[pattern] = re.MustCompile(pattern)
 	return reDict[pattern]
 }

--- a/rexp_test.go
+++ b/rexp_test.go
@@ -57,3 +57,50 @@ func Test_mustCompileRegexp(t *testing.T) {
 
 	assert.Panics(t, testPanic)
 }
+
+func TestRace_compileRegexp(t *testing.T) {
+	vrex := new(re.Regexp)
+
+	patterns := []string{
+		".*TestRegexp1.*",
+		".*TestRegexp2.*",
+		".*TestRegexp3.*",
+	}
+
+	comp := func(pattern string) {
+		rex, err := compileRegexp(pattern)
+		assert.NoError(t, err)
+		assert.NotNil(t, rex)
+		assert.IsType(t, vrex, rex)
+	}
+
+	for i := 0; i < 20; i++ {
+		t.Run(patterns[i%3], func(t *testing.T) {
+			t.Parallel()
+			comp(patterns[i%3])
+		})
+	}
+}
+
+func TestRace_mustCompileRegexp(t *testing.T) {
+	vrex := new(re.Regexp)
+
+	patterns := []string{
+		".*TestRegexp1.*",
+		".*TestRegexp2.*",
+		".*TestRegexp3.*",
+	}
+
+	comp := func(pattern string) {
+		rex := mustCompileRegexp(pattern)
+		assert.NotNil(t, rex)
+		assert.IsType(t, vrex, rex)
+	}
+
+	for i := 0; i < 20; i++ {
+		t.Run(patterns[i%3], func(t *testing.T) {
+			t.Parallel()
+			comp(patterns[i%3])
+		})
+	}
+}


### PR DESCRIPTION
The original implementation allows for read to happen without acquiring lock.
This leads to data race when read and write happen concurrently.

Although tempting, first implementation used sync.Map, which optimize for a map that's used as cache concurrently.
Later changed it back to mutex for support of go 1.8 as sync.Map is introduced in go 1.9

Fixes #87 