### PR TITLE
Fix debug logger side effects

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -26,6 +26,8 @@ var (
 	// Debug is true when the SWAGGER_DEBUG env var is not empty.
 	// It enables a more verbose logging of validators.
 	Debug = os.Getenv("SWAGGER_DEBUG") != ""
+	// validateLogger is a debug logger for this package
+	validateLogger *log.Logger
 )
 
 func init() {
@@ -33,17 +35,13 @@ func init() {
 }
 
 func debugOptions() {
-	if Debug {
-		//log.SetFlags(log.LstdFlags | log.Lshortfile)
-		log.SetFlags(log.LstdFlags)
-		log.SetPrefix("validate:")
-	}
+	validateLogger = log.New(os.Stdout, "validate:", log.LstdFlags)
 }
 
 func debugLog(msg string, args ...interface{}) {
 	// A private, trivial trace logger, based on go-openapi/spec/expander.go:debugLog()
 	if Debug {
 		_, file1, pos1, _ := runtime.Caller(1)
-		log.Printf("%s:%d: %s", filepath.Base(file1), pos1, fmt.Sprintf(msg, args...))
+		validateLogger.Printf("%s:%d: %s", filepath.Base(file1), pos1, fmt.Sprintf(msg, args...))
 	}
 }

--- a/debug_test.go
+++ b/debug_test.go
@@ -16,7 +16,6 @@ package validate
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"sync"
 	"testing"
@@ -37,7 +36,6 @@ func TestDebug(t *testing.T) {
 	tmpName := tmpFile.Name()
 	defer func() {
 		Debug = false
-		log.SetOutput(os.Stdout)
 		// mutex for -race
 		logMutex.Unlock()
 		os.Remove(tmpName)
@@ -45,15 +43,21 @@ func TestDebug(t *testing.T) {
 
 	// mutex for -race
 	logMutex.Lock()
-	log.SetOutput(tmpFile)
 	Debug = true
 	debugOptions()
+	defer func() {
+		validateLogger.SetOutput(os.Stdout)
+	}()
+
+	validateLogger.SetOutput(tmpFile)
+
 	debugLog("A debug")
 	Debug = false
 	tmpFile.Close()
+
 	flushed, _ := os.Open(tmpName)
 	buf := make([]byte, 500)
 	flushed.Read(buf)
-	log.SetOutput(os.Stdout)
+	validateLogger.SetOutput(os.Stdout)
 	assert.Contains(t, string(buf), "A debug")
 }


### PR DESCRIPTION
A previous improvement in signing the package name with debug log entries
did actually pollute the global logger settings.

Now fixed with a private debug logger for this package.