### PR TITLE
When validating an array, validate that the provided items is indeed one

### DIFF
--- a/object_validator.go
+++ b/object_validator.go
@@ -58,8 +58,15 @@ func (o *objectValidator) isPropertyName() bool {
 func (o *objectValidator) checkArrayMustHaveItems(res *Result, val map[string]interface{}) {
 	if t, typeFound := val["type"]; typeFound {
 		if tpe, ok := t.(string); ok && tpe == "array" {
-			if _, itemsKeyFound := val["items"]; !itemsKeyFound {
+			items, itemsKeyFound := val["items"]
+			if !itemsKeyFound {
 				res.AddErrors(errors.Required("items", o.Path))
+				return
+			}
+
+			t := reflect.TypeOf(items)
+			if t.Kind() != reflect.Array && t.Kind() != reflect.Slice {
+				res.AddErrors(errors.InvalidType(o.Path, o.In, "array", nil))
 			}
 		}
 	}

--- a/object_validator_test.go
+++ b/object_validator_test.go
@@ -21,16 +21,27 @@ func TestItemsMustBeTypeArray(t *testing.T) {
 	ov := new(objectValidator)
 	dataValid := map[string]interface{}{
 		"type":  "array",
-		"items": "dummy",
+		"items": []string{"dummy"},
 	}
-	dataInvalid := map[string]interface{}{
-		"type":  "object",
-		"items": "dummy",
+	dataInvalid := map[string]map[string]interface{}{
+		"with a type of object": {
+			"type":  "object",
+			"items": "dummy",
+		},
+		"with items not as an array": {
+			"type":  "array",
+			"items": "dummy",
+		},
 	}
 	res := ov.Validate(dataValid)
 	assert.Equal(t, 0, len(res.Errors))
-	res = ov.Validate(dataInvalid)
-	assert.NotEqual(t, 0, len(res.Errors))
+
+	for k, d := range dataInvalid {
+		t.Run(k, func(t *testing.T) {
+			res = ov.Validate(d)
+			assert.NotEqual(t, 0, len(res.Errors))
+		})
+	}
 }
 
 func TestItemsMustHaveType(t *testing.T) {


### PR DESCRIPTION
Without this, we could have a type of array, and validation would pass for any value provided, such as a string.