### PR TITLE
Add nullable

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -174,7 +174,7 @@ func (s *SchemaValidator) Validate(data interface{}) *Result {
 }
 
 func (s *SchemaValidator) typeValidator() valueValidator {
-	return &typeValidator{Type: s.Schema.Type, Format: s.Schema.Format, In: s.in, Path: s.Path}
+	return &typeValidator{Type: s.Schema.Type, Nullable: s.Schema.Nullable, Format: s.Schema.Format, In: s.in, Path: s.Path}
 }
 
 func (s *SchemaValidator) commonValidator() valueValidator {

--- a/type.go
+++ b/type.go
@@ -26,10 +26,11 @@ import (
 )
 
 type typeValidator struct {
-	Type   spec.StringOrArray
-	Format string
-	In     string
-	Path   string
+	Type     spec.StringOrArray
+	Nullable bool
+	Format   string
+	In       string
+	Path     string
 }
 
 func (t *typeValidator) schemaInfoForType(data interface{}) (string, string) {
@@ -138,7 +139,7 @@ func (t *typeValidator) Validate(data interface{}) *Result {
 	result.Inc()
 	if data == nil || reflect.DeepEqual(reflect.Zero(reflect.TypeOf(data)), reflect.ValueOf(data)) {
 		// nil or zero value for the passed structure require Type: null
-		if len(t.Type) > 0 && !t.Type.Contains("null") { // TODO: if a property is not required it also passes this
+		if len(t.Type) > 0 && !t.Type.Contains("null") && !t.Nullable { // TODO: if a property is not required it also passes this
 			return errorHelp.sErr(errors.InvalidType(t.Path, t.In, strings.Join(t.Type, ","), "null"))
 		}
 		return result

--- a/validator.go
+++ b/validator.go
@@ -47,10 +47,11 @@ func newItemsValidator(path, in string, items *spec.Items, root interface{}, for
 	iv := &itemsValidator{path: path, in: in, items: items, root: root, KnownFormats: formats}
 	iv.validators = []valueValidator{
 		&typeValidator{
-			Type:   spec.StringOrArray([]string{items.Type}),
-			Format: items.Format,
-			In:     in,
-			Path:   path,
+			Type:     spec.StringOrArray([]string{items.Type}),
+			Nullable: items.Nullable,
+			Format:   items.Format,
+			In:       in,
+			Path:     path,
 		},
 		iv.stringValidator(),
 		iv.formatValidator(),
@@ -186,10 +187,11 @@ func NewHeaderValidator(name string, header *spec.Header, formats strfmt.Registr
 	p := &HeaderValidator{name: name, header: header, KnownFormats: formats}
 	p.validators = []valueValidator{
 		&typeValidator{
-			Type:   spec.StringOrArray([]string{header.Type}),
-			Format: header.Format,
-			In:     "header",
-			Path:   name,
+			Type:     spec.StringOrArray([]string{header.Type}),
+			Nullable: header.Nullable,
+			Format:   header.Format,
+			In:       "header",
+			Path:     name,
 		},
 		p.stringValidator(),
 		p.formatValidator(),
@@ -292,10 +294,11 @@ func NewParamValidator(param *spec.Parameter, formats strfmt.Registry) *ParamVal
 	p := &ParamValidator{param: param, KnownFormats: formats}
 	p.validators = []valueValidator{
 		&typeValidator{
-			Type:   spec.StringOrArray([]string{param.Type}),
-			Format: param.Format,
-			In:     param.In,
-			Path:   param.Name,
+			Type:     spec.StringOrArray([]string{param.Type}),
+			Nullable: param.Nullable,
+			Format:   param.Format,
+			In:       param.In,
+			Path:     param.Name,
 		},
 		p.stringValidator(),
 		p.formatValidator(),


### PR DESCRIPTION
Towards v3 support, we have to add nullable, as an alternative to the JSON-Schema inspired `null` type.

Note, that both are not 100% the same as `type:"", nullable:true` is a valid construct which cannot be faithfully represented with the `null` type only.

Counterpart PR to https://github.com/go-openapi/spec/pull/91.