### PR TITLE
Add parameter type and validation match check

### DIFF
--- a/fixtures/validation/type-keyword-mismatch.yaml
+++ b/fixtures/validation/type-keyword-mismatch.yaml
@@ -1,0 +1,47 @@
+swagger: '2.0'
+info:
+  description: Validation keyword type mismatch
+  version: 0.0.1
+  title: test
+paths:
+  /test/{id}/string:
+    get:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: string
+          maximum: 5
+      responses:
+        '200':
+          description: successful operation
+        '500':
+          description: Operation error
+
+  /test/{id}/integer:
+    get:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+          maxItems: 5
+      responses:
+        '200':
+          description: successful operation
+        '500':
+          description: Operation error
+
+  /test/{id}/array:
+    get:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: array
+          maxLength: 5
+      responses:
+        '200':
+          description: successful operation
+        '500':
+          description: Operation error

--- a/fixtures/validation/type-keyword-mismatch.yaml
+++ b/fixtures/validation/type-keyword-mismatch.yaml
@@ -11,7 +11,9 @@ paths:
           in: path
           required: true
           type: string
+          minimum: 1
           maximum: 5
+          multipleOf: 33
       responses:
         '200':
           description: successful operation
@@ -25,7 +27,9 @@ paths:
           in: path
           required: true
           type: integer
+          minItems: 1
           maxItems: 5
+          uniqueItems: true
       responses:
         '200':
           description: successful operation
@@ -39,6 +43,7 @@ paths:
           in: path
           required: true
           type: array
+          minLength: 1
           maxLength: 5
       responses:
         '200':

--- a/helpers.go
+++ b/helpers.go
@@ -27,7 +27,16 @@ import (
 )
 
 const swaggerBody = "body"
-const objectType = "object"
+
+const (
+	objectType  = "object"
+	arrayType   = "array"
+	stringType  = "string"
+	integerType = "integer"
+	numberType  = "number"
+	booleanType = "boolean"
+	fileType    = "file"
+)
 
 // Helpers available at the package level
 var (

--- a/object_validator.go
+++ b/object_validator.go
@@ -58,7 +58,7 @@ func (o *objectValidator) isPropertyName() bool {
 
 func (o *objectValidator) checkArrayMustHaveItems(res *Result, val map[string]interface{}) {
 	if t, typeFound := val["type"]; typeFound {
-		if tpe, ok := t.(string); ok && tpe == "array" {
+		if tpe, ok := t.(string); ok && tpe == arrayType {
 			if _, itemsKeyFound := val["items"]; !itemsKeyFound {
 				res.AddErrors(errors.Required("items", o.Path))
 			}
@@ -71,8 +71,8 @@ func (o *objectValidator) checkItemsMustBeTypeArray(res *Result, val map[string]
 		if _, itemsKeyFound := val["items"]; itemsKeyFound {
 			t, typeFound := val["type"]
 			if typeFound {
-				if tpe, ok := t.(string); !ok || tpe != "array" {
-					res.AddErrors(errors.InvalidType(o.Path, o.In, "array", nil))
+				if tpe, ok := t.(string); !ok || tpe != arrayType {
+					res.AddErrors(errors.InvalidType(o.Path, o.In, arrayType, nil))
 				}
 			} else {
 				// there is no type

--- a/schema.go
+++ b/schema.go
@@ -134,9 +134,9 @@ func (s *SchemaValidator) Validate(data interface{}) *Result {
 
 	// TODO: this part should be handed over to type validator
 	// Handle special case of json.Number data (number marshalled as string)
-	isnumber := s.Schema.Type.Contains("number") || s.Schema.Type.Contains("integer")
+	isnumber := s.Schema.Type.Contains(numberType) || s.Schema.Type.Contains(integerType)
 	if num, ok := data.(json.Number); ok && isnumber {
-		if s.Schema.Type.Contains("integer") { // avoid lossy conversion
+		if s.Schema.Type.Contains(integerType) { // avoid lossy conversion
 			in, erri := num.Int64()
 			if erri != nil {
 				result.AddErrors(invalidTypeConversionMsg(s.Path, erri))

--- a/spec.go
+++ b/spec.go
@@ -681,6 +681,24 @@ func (s *SpecValidator) validateParameters() *Result {
 					if pr.In == "formData" {
 						hasForm = true
 					}
+
+					if !(pr.Type == "number" || pr.Type == "integer") &&
+						(pr.Maximum != nil || pr.Minimum != nil) {
+						// A non-numeric parameter has validation keywords for numeric instances (number and integer)
+						res.AddWarnings(parameterValidationTypeMismatchMsg(pr.Name, path, pr.Type))
+					}
+
+					if !(pr.Type == "string") &&
+						// A non-string parameter has validation keywords for strings
+						(pr.MaxLength != nil || pr.MinLength != nil || pr.Pattern != "") {
+						res.AddWarnings(parameterValidationTypeMismatchMsg(pr.Name, path, pr.Type))
+					}
+
+					if !(pr.Type == "array") &&
+						// A non-array parameter has validation keywords for arrays
+						(pr.MaxItems != nil || pr.MinItems != nil || pr.UniqueItems == true) {
+						res.AddWarnings(parameterValidationTypeMismatchMsg(pr.Name, path, pr.Type))
+					}
 				}
 
 				// In:formData and In:body are mutually exclusive

--- a/spec.go
+++ b/spec.go
@@ -336,14 +336,14 @@ func (s *SpecValidator) validateItems() *Result {
 		for path, op := range pi {
 			for _, param := range paramHelp.safeExpandedParamsFor(path, method, op.ID, res, s) {
 
-				if param.TypeName() == "array" && param.ItemsTypeName() == "" {
+				if param.TypeName() == arrayType && param.ItemsTypeName() == "" {
 					res.AddErrors(arrayInParamRequiresItemsMsg(param.Name, op.ID))
 					continue
 				}
 				if param.In != "body" {
 					if param.Items != nil {
 						items := param.Items
-						for items.TypeName() == "array" {
+						for items.TypeName() == arrayType {
 							if items.ItemsTypeName() == "" {
 								res.AddErrors(arrayInParamRequiresItemsMsg(param.Name, op.ID))
 								break
@@ -374,7 +374,7 @@ func (s *SpecValidator) validateItems() *Result {
 			for _, resp := range responses {
 				// Response headers with array
 				for hn, hv := range resp.Headers {
-					if hv.TypeName() == "array" && hv.ItemsTypeName() == "" {
+					if hv.TypeName() == arrayType && hv.ItemsTypeName() == "" {
 						res.AddErrors(arrayInHeaderRequiresItemsMsg(hn, op.ID))
 					}
 				}
@@ -390,7 +390,7 @@ func (s *SpecValidator) validateItems() *Result {
 // Verifies constraints on array type
 func (s *SpecValidator) validateSchemaItems(schema spec.Schema, prefix, opID string) *Result {
 	res := new(Result)
-	if !schema.Type.Contains("array") {
+	if !schema.Type.Contains(arrayType) {
 		return res
 	}
 
@@ -682,21 +682,21 @@ func (s *SpecValidator) validateParameters() *Result {
 						hasForm = true
 					}
 
-					if !(pr.Type == "number" || pr.Type == "integer") &&
+					if !(pr.Type == numberType || pr.Type == integerType) &&
 						(pr.Maximum != nil || pr.Minimum != nil) {
 						// A non-numeric parameter has validation keywords for numeric instances (number and integer)
 						res.AddWarnings(parameterValidationTypeMismatchMsg(pr.Name, path, pr.Type))
 					}
 
-					if !(pr.Type == "string") &&
+					if !(pr.Type == stringType) &&
 						// A non-string parameter has validation keywords for strings
 						(pr.MaxLength != nil || pr.MinLength != nil || pr.Pattern != "") {
 						res.AddWarnings(parameterValidationTypeMismatchMsg(pr.Name, path, pr.Type))
 					}
 
-					if !(pr.Type == "array") &&
+					if !(pr.Type == arrayType) &&
 						// A non-array parameter has validation keywords for arrays
-						(pr.MaxItems != nil || pr.MinItems != nil || pr.UniqueItems == true) {
+						(pr.MaxItems != nil || pr.MinItems != nil || pr.UniqueItems) {
 						res.AddWarnings(parameterValidationTypeMismatchMsg(pr.Name, path, pr.Type))
 					}
 				}

--- a/spec.go
+++ b/spec.go
@@ -683,7 +683,7 @@ func (s *SpecValidator) validateParameters() *Result {
 					}
 
 					if !(pr.Type == numberType || pr.Type == integerType) &&
-						(pr.Maximum != nil || pr.Minimum != nil) {
+						(pr.Maximum != nil || pr.Minimum != nil || pr.MultipleOf != nil) {
 						// A non-numeric parameter has validation keywords for numeric instances (number and integer)
 						res.AddWarnings(parameterValidationTypeMismatchMsg(pr.Name, path, pr.Type))
 					}

--- a/spec_messages.go
+++ b/spec_messages.go
@@ -163,6 +163,9 @@ const (
 	// PathParamGarbledWarning ...
 	PathParamGarbledWarning = "in path %q, param %q contains {,} or white space. Albeit not stricly illegal, this is probably no what you want"
 
+	// ParamValidationTypeMismatch indicates that parameter has validation which does not match its type
+	ParamValidationTypeMismatch = "validation keywords of parameter %q in path %q don't match its type %s"
+
 	// PathStrippedParamGarbledWarning ...
 	PathStrippedParamGarbledWarning = "path stripped from path parameters %s contains {,} or white space. This is probably no what you want."
 
@@ -340,6 +343,9 @@ func invalidParameterDefinitionMsg(path, method, operationID string) errors.Erro
 }
 func invalidParameterDefinitionAsSchemaMsg(path, method, operationID string) errors.Error {
 	return errors.New(errors.CompositeErrorCode, InvalidParameterDefinitionAsSchemaError, path, method, operationID)
+}
+func parameterValidationTypeMismatchMsg(param, path, typ string) errors.Error {
+	return errors.New(errors.CompositeErrorCode, ParamValidationTypeMismatch, param, path, typ)
 }
 
 // disabled

--- a/spec_test.go
+++ b/spec_test.go
@@ -796,3 +796,22 @@ func TestSpec_Issue1341(t *testing.T) {
 		assert.Empty(t, res.Warnings, "in fixture-1341-5.yaml")
 	}
 }
+
+func TestSpec_ValidationTypeMismatch(t *testing.T) {
+	doc, err := loads.Spec(filepath.Join("fixtures", "validation", "type-keyword-mismatch.yaml"))
+	if assert.NoError(t, err) {
+		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
+		validator.spec = doc
+		validator.analyzer = analysis.New(doc.Spec())
+		res := validator.validateParameters()
+		var warnings []string
+		for _, w := range res.Warnings {
+			warnings = append(warnings, w.Error())
+		}
+		assert.NotEmpty(t, res.Warnings)
+		assert.Len(t, res.Warnings, 3)
+		assert.Contains(t, warnings, `validation keywords of parameter "id" in path "/test/{id}/string" don't match its type string`)
+		assert.Contains(t, warnings, `validation keywords of parameter "id" in path "/test/{id}/integer" don't match its type integer`)
+		assert.Contains(t, warnings, `validation keywords of parameter "id" in path "/test/{id}/array" don't match its type array`)
+	}
+}

--- a/type.go
+++ b/type.go
@@ -111,7 +111,7 @@ func (t *typeValidator) schemaInfoForType(data interface{}) (string, string) {
 		case reflect.Slice:
 			return arrayType, ""
 		case reflect.Map, reflect.Struct:
-			return "object", ""
+			return objectType, ""
 		case reflect.Interface:
 			// What to do here?
 			panic("dunno what to do here")

--- a/type.go
+++ b/type.go
@@ -39,53 +39,53 @@ func (t *typeValidator) schemaInfoForType(data interface{}) (string, string) {
 	// TODO: this switch really is some sort of reverse lookup for formats. It should be provided by strfmt.
 	switch data.(type) {
 	case []byte, strfmt.Base64, *strfmt.Base64:
-		return "string", "byte"
+		return stringType, "byte"
 	case strfmt.CreditCard, *strfmt.CreditCard:
-		return "string", "creditcard"
+		return stringType, "creditcard"
 	case strfmt.Date, *strfmt.Date:
-		return "string", "date"
+		return stringType, "date"
 	case strfmt.DateTime, *strfmt.DateTime:
-		return "string", "date-time"
+		return stringType, "date-time"
 	case strfmt.Duration, *strfmt.Duration:
-		return "string", "duration"
+		return stringType, "duration"
 	case runtime.File, *runtime.File:
-		return "file", ""
+		return fileType, ""
 	case strfmt.Email, *strfmt.Email:
-		return "string", "email"
+		return stringType, "email"
 	case strfmt.HexColor, *strfmt.HexColor:
-		return "string", "hexcolor"
+		return stringType, "hexcolor"
 	case strfmt.Hostname, *strfmt.Hostname:
-		return "string", "hostname"
+		return stringType, "hostname"
 	case strfmt.IPv4, *strfmt.IPv4:
-		return "string", "ipv4"
+		return stringType, "ipv4"
 	case strfmt.IPv6, *strfmt.IPv6:
-		return "string", "ipv6"
+		return stringType, "ipv6"
 	case strfmt.ISBN, *strfmt.ISBN:
-		return "string", "isbn"
+		return stringType, "isbn"
 	case strfmt.ISBN10, *strfmt.ISBN10:
-		return "string", "isbn10"
+		return stringType, "isbn10"
 	case strfmt.ISBN13, *strfmt.ISBN13:
-		return "string", "isbn13"
+		return stringType, "isbn13"
 	case strfmt.MAC, *strfmt.MAC:
-		return "string", "mac"
+		return stringType, "mac"
 	case strfmt.ObjectId, *strfmt.ObjectId:
-		return "string", "bsonobjectid"
+		return stringType, "bsonobjectid"
 	case strfmt.Password, *strfmt.Password:
-		return "string", "password"
+		return stringType, "password"
 	case strfmt.RGBColor, *strfmt.RGBColor:
-		return "string", "rgbcolor"
+		return stringType, "rgbcolor"
 	case strfmt.SSN, *strfmt.SSN:
-		return "string", "ssn"
+		return stringType, "ssn"
 	case strfmt.URI, *strfmt.URI:
-		return "string", "uri"
+		return stringType, "uri"
 	case strfmt.UUID, *strfmt.UUID:
-		return "string", "uuid"
+		return stringType, "uuid"
 	case strfmt.UUID3, *strfmt.UUID3:
-		return "string", "uuid3"
+		return stringType, "uuid3"
 	case strfmt.UUID4, *strfmt.UUID4:
-		return "string", "uuid4"
+		return stringType, "uuid4"
 	case strfmt.UUID5, *strfmt.UUID5:
-		return "string", "uuid5"
+		return stringType, "uuid5"
 	// TODO: missing binary (io.ReadCloser)
 	// TODO: missing json.Number
 	default:
@@ -93,23 +93,23 @@ func (t *typeValidator) schemaInfoForType(data interface{}) (string, string) {
 		tpe := val.Type()
 		switch tpe.Kind() {
 		case reflect.Bool:
-			return "boolean", ""
+			return booleanType, ""
 		case reflect.String:
-			return "string", ""
+			return stringType, ""
 		case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint8, reflect.Uint16, reflect.Uint32:
 			// NOTE: that is the spec. With go-openapi, is that not uint32 for unsigned integers?
-			return "integer", "int32"
+			return integerType, "int32"
 		case reflect.Int, reflect.Int64, reflect.Uint, reflect.Uint64:
-			return "integer", "int64"
+			return integerType, "int64"
 		case reflect.Float32:
 			// NOTE: is that not "float"?
-			return "number", "float32"
+			return numberType, "float32"
 		case reflect.Float64:
 			// NOTE: is that not "double"?
-			return "number", "float64"
+			return numberType, "float64"
 		// NOTE: go arrays (reflect.Array) are not supported (fixed length)
 		case reflect.Slice:
-			return "array", ""
+			return arrayType, ""
 		case reflect.Map, reflect.Struct:
 			return "object", ""
 		case reflect.Interface:
@@ -159,15 +159,15 @@ func (t *typeValidator) Validate(data interface{}) *Result {
 	// TODO: check json.Number (see schema.go)
 	isLowerInt := t.Format == "int64" && format == "int32"
 	isLowerFloat := t.Format == "float64" && format == "float32"
-	isFloatInt := schType == "number" && swag.IsFloat64AJSONInteger(val.Float()) && t.Type.Contains("integer")
-	isIntFloat := schType == "integer" && t.Type.Contains("number")
+	isFloatInt := schType == numberType && swag.IsFloat64AJSONInteger(val.Float()) && t.Type.Contains(integerType)
+	isIntFloat := schType == integerType && t.Type.Contains(numberType)
 
 	if kind != reflect.String && kind != reflect.Slice && t.Format != "" && !(t.Type.Contains(schType) || format == t.Format || isFloatInt || isIntFloat || isLowerInt || isLowerFloat) {
 		// TODO: test case
 		return errorHelp.sErr(errors.InvalidType(t.Path, t.In, t.Format, format))
 	}
 
-	if !(t.Type.Contains("number") || t.Type.Contains("integer")) && t.Format != "" && (kind == reflect.String || kind == reflect.Slice) {
+	if !(t.Type.Contains(numberType) || t.Type.Contains(integerType)) && t.Format != "" && (kind == reflect.String || kind == reflect.Slice) {
 		return result
 	}
 

--- a/validator.go
+++ b/validator.go
@@ -611,7 +611,7 @@ func (s *stringValidator) Applies(source interface{}, kind reflect.Kind) bool {
 func (s *stringValidator) Validate(val interface{}) *Result {
 	data, ok := val.(string)
 	if !ok {
-		return errorHelp.sErr(errors.InvalidType(s.Path, s.In, "string", val))
+		return errorHelp.sErr(errors.InvalidType(s.Path, s.In, stringType, val))
 	}
 
 	if s.Required && !s.AllowEmptyValue && (s.Default == nil || s.Default == "") {

--- a/values.go
+++ b/values.go
@@ -361,7 +361,7 @@ func IsValueValidAgainstRange(val interface{}, typeName, format, prefix, path st
 	var errVal error
 
 	switch typeName {
-	case "integer":
+	case integerType:
 		switch format {
 		case "int32":
 			_, errVal = swag.ConvertInt32(stringRep)
@@ -374,7 +374,7 @@ func IsValueValidAgainstRange(val interface{}, typeName, format, prefix, path st
 		default:
 			_, errVal = swag.ConvertInt64(stringRep)
 		}
-	case "number":
+	case numberType:
 		fallthrough
 	default:
 		switch format {


### PR DESCRIPTION
According to [2069](https://github.com/go-swagger/go-swagger/issues/2069) of go-swagger, this adds a validation if parameter type matches its validation keywords.