### PR TITLE
Bump go-yaml version to cover fixed ddos heuristic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-openapi/swag v0.19.5
 	github.com/stretchr/testify v1.4.0
 	go.mongodb.org/mongo-driver v1.1.1 // indirect
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.4
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -133,3 +133,5 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This PR bumbs go-yaml to v2.2.4, which has the ddos vulnerability fixed.

Issue:
go-yaml preceding 2.2.4 had vulnerability to ddos attack via billion
laughs bomb.
Such attack lead to program to be unresponsive.
Issue has been described in
https://raesene.github.io/blog/2019/10/15/From-stackoverflow-to-CVE/

Signed-off-by: Petr Kotas <petr.kotas@gmail.com>