### PR TITLE
Fixes issues related to swagger-specific rules with array schemas and items

### DIFF
--- a/debug_test.go
+++ b/debug_test.go
@@ -57,7 +57,7 @@ func TestDebug(t *testing.T) {
 
 	flushed, _ := os.Open(tmpName)
 	buf := make([]byte, 500)
-	flushed.Read(buf)
+	_, _ = flushed.Read(buf)
 	validateLogger.SetOutput(os.Stdout)
 	assert.Contains(t, string(buf), "A debug")
 }

--- a/default_validator.go
+++ b/default_validator.go
@@ -224,7 +224,7 @@ func (d *defaultValidator) validateDefaultValueSchemaAgainstSchema(path, in stri
 	s := d.SpecValidator
 
 	if schema.Default != nil {
-		res.Merge(NewSchemaValidator(schema, s.spec.Spec(), path+".default", s.KnownFormats).Validate(schema.Default))
+		res.Merge(NewSchemaValidator(schema, s.spec.Spec(), path+".default", s.KnownFormats, SwaggerSchema(true)).Validate(schema.Default))
 	}
 	if schema.Items != nil {
 		if schema.Items.Schema != nil {

--- a/doc_test.go
+++ b/doc_test.go
@@ -138,13 +138,13 @@ func ExampleAgainstSchema() {
 }`
 
 	schema := new(spec.Schema)
-	json.Unmarshal([]byte(schemaJSON), schema)
+	_ = json.Unmarshal([]byte(schemaJSON), schema)
 
 	input := map[string]interface{}{}
 
 	// JSON data to validate
 	inputJSON := `{"name": "Ivan","address-1": "sesame street"}`
-	json.Unmarshal([]byte(inputJSON), &input)
+	_ = json.Unmarshal([]byte(inputJSON), &input)
 
 	// strfmt.Default is the registry of recognized formats
 	err := validate.AgainstSchema(schema, input, strfmt.Default)

--- a/doc_test.go
+++ b/doc_test.go
@@ -17,11 +17,13 @@ package validate_test
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
 
 	"github.com/go-openapi/loads" // Spec loading
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/strfmt"   // OpenAPI format extensions
 	"github.com/go-openapi/validate" // This package
+	"github.com/stretchr/testify/require"
 )
 
 func ExampleSpec() {
@@ -155,4 +157,26 @@ func ExampleAgainstSchema() {
 	}
 	// Output:
 	// OK
+}
+
+func TestValidate_Issue112(t *testing.T) {
+	t.Run("returns no error on body includes `items` key", func(t *testing.T) {
+		body := map[string]interface{}{"items1": nil}
+		err := validate.AgainstSchema(getSimpleSchema(), body, strfmt.Default)
+		require.NoError(t, err)
+	})
+
+	t.Run("returns no error when body includes `items` key", func(t *testing.T) {
+		body := map[string]interface{}{"items": nil}
+		err := validate.AgainstSchema(getSimpleSchema(), body, strfmt.Default)
+		require.NoError(t, err)
+	})
+}
+
+func getSimpleSchema() *spec.Schema {
+	return &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: spec.StringOrArray{"object"},
+		},
+	}
 }

--- a/example_validator.go
+++ b/example_validator.go
@@ -191,7 +191,7 @@ func (ex *exampleValidator) validateExampleInResponse(resp *spec.Response, respo
 	if response.Examples != nil {
 		if response.Schema != nil {
 			if example, ok := response.Examples["application/json"]; ok {
-				res.MergeAsWarnings(NewSchemaValidator(response.Schema, s.spec.Spec(), path, s.KnownFormats).Validate(example))
+				res.MergeAsWarnings(NewSchemaValidator(response.Schema, s.spec.Spec(), path+".examples", s.KnownFormats, SwaggerSchema(true)).Validate(example))
 			} else {
 				// TODO: validate other media types too
 				res.AddWarnings(examplesMimeNotSupportedMsg(operationID, responseName))
@@ -213,7 +213,7 @@ func (ex *exampleValidator) validateExampleValueSchemaAgainstSchema(path, in str
 	res := new(Result)
 
 	if schema.Example != nil {
-		res.MergeAsWarnings(NewSchemaValidator(schema, s.spec.Spec(), path+".example", s.KnownFormats).Validate(schema.Example))
+		res.MergeAsWarnings(NewSchemaValidator(schema, s.spec.Spec(), path+".example", s.KnownFormats, SwaggerSchema(true)).Validate(schema.Example))
 	}
 	if schema.Items != nil {
 		if schema.Items.Schema != nil {

--- a/fixtures/bugs/43/fixture-1456.yaml
+++ b/fixtures/bugs/43/fixture-1456.yaml
@@ -1,0 +1,49 @@
+swagger: '2.0'
+info:
+  title: fixture
+  description: reproduce fixture go-swagger/go-swagger#1456
+  version: "1.0.0"
+paths:
+  /v1/collection:
+    post:
+      summary: Collection
+      tags:
+        - Collection
+      parameters:
+        - name: collection
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/collection'
+      responses:
+        200:
+          description: success
+          schema:
+            type: string
+definitions:
+  collection:
+    type: object
+    required:
+      - id
+      - title
+      - items
+    properties:
+      id:
+        type: string
+        description: The unique ID
+      title:
+        type: string
+        description: Title
+        minLength: 1
+        maxLength: 50
+      items:
+        type: array
+        description: Items
+        items:
+          type: string
+    example:
+      id: item1
+      title: Home
+      items:
+      - item2
+      - item3

--- a/fixtures/bugs/43/fixture-43-fail.yaml
+++ b/fixtures/bugs/43/fixture-43-fail.yaml
@@ -1,0 +1,27 @@
+swagger: '2.0'
+info:
+  title: Object
+  version: 0.1.0
+
+paths:
+  "/":
+    get:
+      operationId: getBody
+      parameters:
+        - name: yet_other_server_id
+          in: body
+          schema:
+            # Invalid array definition
+            type: array
+            properties:
+              other:
+                type: string
+      responses:
+        '200':
+          description: ko
+            # Invalid array definition
+          schema:
+            type: array
+            properties:
+              another:
+                type: string

--- a/fixtures/bugs/43/fixture-43-variants.yaml
+++ b/fixtures/bugs/43/fixture-43-variants.yaml
@@ -1,0 +1,71 @@
+swagger: '2.0'
+info:
+  title: Object
+  version: 0.1.0
+
+paths:
+  /:
+    get:
+      parameters:
+        - name: itemsparam
+          in: body
+          schema:
+            type: array
+            items:
+              type: object
+              required: [ items ]
+              properties:
+                items:
+                  type: number
+            example:
+              - items: 123
+              - items: 456
+      responses:
+        '200':
+          description: Ok
+          schema:
+            type: object
+            properties:
+              a:
+                type: string
+              items:
+                type: string
+                default: "xyz"
+                example: "123"
+          examples:
+            application/json:
+              a: abc
+              items: xyz
+  # we verify that it is legal to name a property "type" or "properties"
+  /type:
+    get:
+      parameters:
+        - name: typeparam
+          in: body
+          schema:
+            type: object
+            properties:
+              type:
+                type: string
+                example: z
+              properties:
+                type: number
+                example: 1
+            default: { "type": "abc", "properties": 123 }
+            example: { "type": "abc", "properties": 123 }
+      responses:
+        '200':
+          description: Ok
+          schema:
+            type: object
+            properties:
+              type:
+                type: string
+              properties:
+                type: number
+                default: 123
+                example: 123
+          examples:
+            application/json:
+              type: abc
+              properties: 123

--- a/fixtures/bugs/43/fixture-43.yaml
+++ b/fixtures/bugs/43/fixture-43.yaml
@@ -1,0 +1,20 @@
+swagger: '2.0'
+info:
+  title: Object
+  version: 0.1.0
+
+paths:
+  /:
+    get:
+      responses:
+        '200':
+          description: Ok
+          schema:
+            type: object
+            properties:
+              a:
+                type: string
+              items:
+                type: string
+                default: "xyz"
+                example: "123"

--- a/fixtures/petstore/swagger.json
+++ b/fixtures/petstore/swagger.json
@@ -1,0 +1,280 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "contact": {
+      "name": "Wordnik API Team",
+      "url": "http://developer.wordnik.com"
+    },
+    "license": {
+      "name": "Creative Commons 4.0 International",
+      "url": "http://creativecommons.org/licenses/by/4.0/"
+    }
+  },
+  "host": "petstore.swagger.wordnik.com",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "security": [
+          {
+            "basic": []
+          }
+        ],
+        "tags": [ "Pet Operations" ],
+        "operationId": "getAllPets",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "The status to filter by",
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of results to return",
+            "type": "integer",
+						"format": "int64"
+          }
+        ],
+        "summary": "Finds all pets in the system",
+        "responses": {
+          "200": {
+            "description": "Pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "basic": []
+          }
+        ],
+        "tags": [ "Pet Operations" ],
+        "operationId": "createPet",
+        "summary": "Creates a new pet",
+        "consumes": ["application/x-yaml"],
+        "produces": ["application/x-yaml"],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "The Pet to create",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/newPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Created Pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "delete": {
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "description": "Deletes the Pet by id",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [ "Pet Operations" ],
+        "operationId": "getPetById",
+        "summary": "Finds the pet by id",
+        "responses": {
+          "200": {
+            "description": "Pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of pet",
+          "required": true,
+          "type": "integer",
+          "format": "int64"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "Category": {
+      "id": "Category",
+      "properties": {
+        "id": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Pet": {
+      "id": "Pet",
+      "properties": {
+        "category": {
+          "$ref": "#/definitions/Category"
+        },
+        "id": {
+          "description": "unique identifier for the pet",
+          "format": "int64",
+          "maximum": 100.0,
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "photoUrls": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "status": {
+          "description": "pet status in the store",
+          "enum": [
+            "available",
+            "pending",
+            "sold"
+          ],
+          "type": "string"
+        },
+        "tags": {
+          "items": {
+            "$ref": "#/definitions/Tag"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ]
+    },
+    "newPet": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Pet"
+        },
+        {
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    },
+    "Tag": {
+      "id": "Tag",
+      "properties": {
+        "id": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Error": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "consumes": [
+    "application/json",
+    "application/xml"
+  ],
+  "produces": [
+    "application/json",
+    "application/xml",
+    "text/plain",
+    "text/html"
+  ],
+  "securityDefinitions": {
+    "basic": {
+      "type": "basic"
+    },
+    "apiKey": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "X-API-KEY"
+    }
+  }
+}

--- a/fixtures/schemas/int-enum.json
+++ b/fixtures/schemas/int-enum.json
@@ -1,39 +1,41 @@
-{
-  "schema": {
-    "type": "object",
-    "properties": {
+[
+  {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "sizes": {
+          "type": "object",
+          "properties": {
+            "first": {
+              "type": "object",
+              "properties": {
+                "count": {
+                  "type": "integer",
+                  "default": 3,
+                  "enum": [3, 5, 7]
+                }
+              },
+              "required": ["count"]
+            }
+          },
+          "required": ["first"]
+        }
+      },
+      "required": ["sizes"]
+    },
+    "valid": {
       "sizes": {
-        "type": "object",
-        "properties": {
-          "first": {
-            "type": "object",
-            "properties": {
-              "count": {
-                "type": "integer",
-                "default": 3,
-                "enum": [3, 5, 7]
-              }
-            },
-            "required": ["count"]
-          }
-        },
-        "required": ["first"]
+        "first": {
+          "count": 3
+        }
       }
     },
-    "required": ["sizes"]
-  },
-  "valid": {
-    "sizes": {
-      "first": {
-        "count": 3
-      }
-    }
-  },
-  "invalid": {
-    "sizes": {
-      "first": {
-        "count": 2
+    "invalid": {
+      "sizes": {
+        "first": {
+          "count": 2
+        }
       }
     }
   }
-}
+]

--- a/fixtures/validation/expected_messages.yaml
+++ b/fixtures/validation/expected_messages.yaml
@@ -1,9 +1,9 @@
-# 
+#
 # This document specifies messages expecations on tested fixtures (errors and warnings)
 # Messages may be either a plain string (assert.Contains) or a simple regexp (assert.True(regexp.MatchString())
 fixture-items-items.yaml:
   comment: how to get through item.Items in simple schemas
-  todo: 
+  todo:
   expectedLoadError: false
   expectedValid: true
   expectedMessages: []
@@ -12,18 +12,18 @@ fixture-items-items.yaml:
     withContinueOnErrors: false
     isRegexp: false
 valid-referenced.yml:
-  comment: 
-  todo: 
+  comment:
+  todo:
   expectedLoadError: false
   expectedValid: true
   expectedMessages: []
   expectedWarnings: []
 valid-referenced-variants.yaml:
   comment: additional scenarios with failures on additionalProperties and required properties
-  todo: 
+  todo:
   expectedLoadError: false
   expectedValid: false
-  expectedMessages: 
+  expectedMessages:
   - message: 'definitions.lotOfErrors.patternProperties in body is a forbidden property'
     withContinueOnErrors: false
     isRegexp: false
@@ -56,14 +56,14 @@ valid-referenced-variants.yaml:
     withContinueOnErrors: true
     isRegexp: false
 fixture-additional-items.yaml:
-  comment: 
+  comment:
   todo:  unsupported keyword such as additionnalItems should be better reported
   expectedLoadError: false
   expectedValid: true
   expectedMessages: []
   expectedWarnings: []
 fixture-additional-items-2.yaml:
-  comment: 
+  comment:
   todo:  unsupported keyword such as additionnalItems should be better reported
   expectedLoadError: false
   expectedValid: false
@@ -76,7 +76,7 @@ fixture-additional-items-2.yaml:
     isRegexp: false
   expectedWarnings: []
 fixture-additional-items-3.yaml:
-  comment: 
+  comment:
   todo:  unsupported keyword such as additionnalItems should be better reported
   expectedLoadError: false
   expectedValid: false
@@ -133,7 +133,7 @@ fixture-no-json-example.yaml:
     isRegexp: false
 fixture-additional-items-invalid-values.yaml:
   comment: additional testing scenario for default and example values
-  todo:  
+  todo:
   expectedLoadError: false
   expectedValid: false
   expectedMessages:
@@ -232,8 +232,8 @@ fixture-additional-items-invalid-values.yaml:
     withContinueOnErrors: true
     isRegexp: false
 fixture-no-response.yaml:
-  comment: 
-  todo: 
+  comment:
+  todo:
   expectedLoadError: false
   expectedValid: false
   expectedMessages:
@@ -245,8 +245,8 @@ fixture-no-response.yaml:
     isRegexp: false
   expectedWarnings: []
 fixture-empty-paths.json:
-  comment: 
-  todo: 
+  comment:
+  todo:
   expectedLoadError: false
   expectedValid: true
   expectedMessages: []
@@ -256,7 +256,7 @@ fixture-empty-paths.json:
     isRegexp: false
 fixture-patternProperties.json:
   comment: Exercise pattern properties (for default values), with an invalid pattern
-  todo: 
+  todo:
   expectedLoadError: false
   expectedValid: false
   expectedMessages:
@@ -307,7 +307,7 @@ fixture-161-2.json:
     Variant of Issue#161: this is a partially fixed spec. In this version, the
     name param type is fixed, but the default value remains wrongly typed'
 
-  todo: 
+  todo:
   expectedLoadError: false
   expectedValid: false
   expectedMessages:
@@ -326,7 +326,7 @@ fixture-161-2.json:
     isRegexp: false
 fixture-161-good.json:
   comment: 'Issue#161: this is the corresponding corrected spec which should be valid. Ah! But now examples are invalid...'
-  todo: 
+  todo:
   expectedLoadError: false
   expectedValid: true
   expectedMessages: []
@@ -339,7 +339,7 @@ fixture-161-good.json:
     isRegexp: false
 fixture-161.json:
   comment: 'Issue#161: default value as object'
-  todo: 
+  todo:
   expectedLoadError: false
   expectedValid: false
   expectedMessages:
@@ -361,7 +361,7 @@ fixture-161.json:
     isRegexp: false
 fixture-342-2.yaml:
   comment: Botched correction attempt for fixture-342
-  todo: 
+  todo:
   expectedLoadError: true
   expectedValid: false
   expectedMessages:
@@ -456,8 +456,8 @@ fixture-342.yaml:
     withContinueOnErrors: true
     isRegexp: false
 fixture-581-good-numbers.yaml:
-  comment: 
-  todo: 
+  comment:
+  todo:
   expectedLoadError: false
   expectedValid: true
   expectedMessages: []
@@ -471,7 +471,7 @@ fixture-581-good.yaml:
   expectedWarnings: []
 fixture-581-inline-param-format.yaml:
   comment: a collection of error messages raised by format validation
-  todo: 
+  todo:
   expectedLoadError: false
   expectedValid: false
   expectedMessages:
@@ -664,7 +664,7 @@ fixture-581.yaml:
     isRegexp: false
 fixture-859-2.yaml:
   comment: 'Issue#859: clear message on unresolved $ref. Additional scenario with items'
-  todo: 
+  todo:
   expectedLoadError: false
   expectedValid: false
   expectedMessages:
@@ -809,18 +809,18 @@ fixture-1171.yaml:
     withContinueOnErrors: true
     isRegexp: false
   # TODO name missing in path
-  - message: 'items in paths./server/getBody.get.parameters.schema is required' 
+  - message: 'items in paths./server/getBody.get.parameters.schema is required'
     withContinueOnErrors: false
     isRegexp: false
   # TODO name missing in path
-  - message: 'items in paths./servers/{server_id}/zones.get.parameters.schema is required' 
+  - message: 'items in paths./servers/{server_id}/zones.get.parameters.schema is required'
     withContinueOnErrors: false
     isRegexp: false
   # TODO name missing in path
-  - message: 'paths./server/getBody.get.parameters.in in body should be one of [header]' 
+  - message: 'paths./server/getBody.get.parameters.in in body should be one of [header]'
     withContinueOnErrors: false
     isRegexp: false
-  - message: 'paths./server/getBody.get.parameters.name in body is required' 
+  - message: 'paths./server/getBody.get.parameters.name in body is required'
     withContinueOnErrors: false
     isRegexp: false
   - message: 'paths./server/getBody.get.parameters.thestreetwithnoname in body is a forbidden property'
@@ -868,8 +868,7 @@ fixture-1231.yaml:
   - message: '/v1/broker/{customer_id}.id in body must be of type uuid: "mycustomer"'
     withContinueOnErrors: true
     isRegexp: false
-  - message: '/v1/broker/{customer_id}.create_date in body must be of type date-time:
-      "bad-date"'
+  - message: '/v1/broker/{customer_id}.create_date in body must be of type date-time: "bad-date"'
     withContinueOnErrors: true
     isRegexp: false
   - message: 'customer_id in path must be of type uuid: "xyz"'
@@ -1259,8 +1258,8 @@ fixture-constraints-on-numbers.yaml:
   #  withContinueOnErrors: false
   #  isRegexp: false
 fixture-invalid-example-property.yaml:
-  comment: 
-  todo: 
+  comment:
+  todo:
   expectedLoadError: false
   expectedValid: true
   expectedMessages: []
@@ -1272,15 +1271,15 @@ fixture-invalid-example-property.yaml:
     withContinueOnErrors: false
     isRegexp: false
 fixture-valid-example-property.yaml:
-  comment: 
-  todo: 
+  comment:
+  todo:
   expectedLoadError: false
   expectedValid: true
   expectedMessages: []
   expectedWarnings: []
 petstore-expanded.json:
   comment: Fail Ref expansion in ContinueOnErrors mode panics
-  todo: 
+  todo:
   expectedLoadError: false
   expectedValid: false
   expectedMessages:
@@ -1298,7 +1297,7 @@ petstore-expanded.json:
   expectedWarnings: []
 gentest.yaml:
   comment: many parameters situations
-  todo: 
+  todo:
   expectedLoadError: false
   expectedValid: true
   expectedMessages: []
@@ -1311,7 +1310,7 @@ gentest.yaml:
     isRegexp: false
 gentest2.yaml:
   comment: many parameters situations with default values
-  todo: 
+  todo:
   expectedLoadError: false
   expectedValid: true
   expectedMessages: []
@@ -1324,7 +1323,7 @@ gentest2.yaml:
     isRegexp: false
 gentest3.yaml:
   comment: default format in headers
-  todo: 
+  todo:
   expectedLoadError: false
   expectedValid: false
   expectedMessages:

--- a/fixtures/validation/expected_messages.yaml
+++ b/fixtures/validation/expected_messages.yaml
@@ -201,10 +201,10 @@ fixture-additional-items-invalid-values.yaml:
   - message: 'in operation "getGoodOp", example value in response 200 does not validate its schema'
     withContinueOnErrors: true
     isRegexp: false
-  - message: '/servers/getBad1.0.first in body must be of type string: "number"'
+  - message: '/servers/getBad1.examples.0.first in body must be of type string: "number"'
     withContinueOnErrors: true
     isRegexp: false
-  - message: '/servers/getBad1.3.z in body must be of type number: "boolean"'
+  - message: '/servers/getBad1.examples.3.z in body must be of type number: "boolean"'
     withContinueOnErrors: true
     isRegexp: false
   - message: '200.example.0.first in body must be of type string: "number"'
@@ -865,10 +865,10 @@ fixture-1231.yaml:
   - message: 'example value for customer_id in path does not validate its schema'
     withContinueOnErrors: true
     isRegexp: false
-  - message: '/v1/broker/{customer_id}.id in body must be of type uuid: "mycustomer"'
+  - message: '/v1/broker/{customer_id}.examples.id in body must be of type uuid: "mycustomer"'
     withContinueOnErrors: true
     isRegexp: false
-  - message: '/v1/broker/{customer_id}.create_date in body must be of type date-time: "bad-date"'
+  - message: '/v1/broker/{customer_id}.examples.create_date in body must be of type date-time: "bad-date"'
     withContinueOnErrors: true
     isRegexp: false
   - message: 'customer_id in path must be of type uuid: "xyz"'

--- a/formats_test.go
+++ b/formats_test.go
@@ -19,11 +19,11 @@ func TestFormatValidator_EdgeCases(t *testing.T) {
 	// formatValidator applies to: Items, Parameter,Schema
 
 	p := spec.Parameter{}
-	p.Typed("string", "email")
+	p.Typed(stringType, "email")
 	s := spec.Schema{}
-	s.Typed("string", "uuid")
+	s.Typed(stringType, "uuid")
 	i := spec.Items{}
-	i.Typed("string", "datetime")
+	i.Typed(stringType, "datetime")
 
 	sources := []interface{}{&p, &s, &i}
 
@@ -36,5 +36,4 @@ func TestFormatValidator_EdgeCases(t *testing.T) {
 
 	assert.False(t, v.Applies("A string", reflect.String))
 	assert.False(t, v.Applies(nil, reflect.String))
-
 }

--- a/helpers.go
+++ b/helpers.go
@@ -27,7 +27,9 @@ import (
 )
 
 const (
-	swaggerBody = "body"
+	swaggerBody     = "body"
+	swaggerExample  = "example"
+	swaggerExamples = "examples"
 )
 
 const (

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -28,39 +28,30 @@ func TestHelpers_addPointerError(t *testing.T) {
 	assert.Contains(t, msg, "could not resolve reference in path to $ref my ref: my error")
 }
 
+func integerFactory(base int) []interface{} {
+	return []interface{}{
+		base,
+		int8(base),
+		int16(base),
+		int32(base),
+		int64(base),
+		uint(base),
+		uint8(base),
+		uint16(base),
+		uint32(base),
+		uint64(base),
+		float32(base),
+		float64(base),
+	}
+}
+
 // Test cases in private method asInt64()
-// including expected panic() cases
 func TestHelpers_asInt64(t *testing.T) {
-	var r int64
-	r = valueHelp.asInt64(int(3))
-	assert.Equal(t, int64(3), r)
-	r = valueHelp.asInt64(uint(3))
-	assert.Equal(t, int64(3), r)
-	r = valueHelp.asInt64(int8(3))
-	assert.Equal(t, int64(3), r)
-	r = valueHelp.asInt64(uint8(3))
-	assert.Equal(t, int64(3), r)
-	r = valueHelp.asInt64(int16(3))
-	assert.Equal(t, int64(3), r)
-	r = valueHelp.asInt64(uint16(3))
-	assert.Equal(t, int64(3), r)
-	r = valueHelp.asInt64(int32(3))
-	assert.Equal(t, int64(3), r)
-	r = valueHelp.asInt64(uint32(3))
-	assert.Equal(t, int64(3), r)
-	r = valueHelp.asInt64(int64(3))
-	assert.Equal(t, int64(3), r)
-	r = valueHelp.asInt64(uint64(3))
-	assert.Equal(t, int64(3), r)
-	r = valueHelp.asInt64(float32(3))
-	assert.Equal(t, int64(3), r)
-	r = valueHelp.asInt64(float64(3))
-	assert.Equal(t, int64(3), r)
+	for _, v := range integerFactory(3) {
+		assert.Equal(t, int64(3), valueHelp.asInt64(v))
+	}
 
 	// Non numeric
-	//assert.PanicsWithValue(t, "Non numeric value in asInt64()", func() {
-	//	valueHelp.asInt64("123")
-	//})
 	if assert.NotPanics(t, func() {
 		valueHelp.asInt64("123")
 	}) {
@@ -69,38 +60,12 @@ func TestHelpers_asInt64(t *testing.T) {
 }
 
 // Test cases in private method asUint64()
-// including expected panic() cases
 func TestHelpers_asUint64(t *testing.T) {
-	var r uint64
-	r = valueHelp.asUint64(int(3))
-	assert.Equal(t, uint64(3), r)
-	r = valueHelp.asUint64(uint(3))
-	assert.Equal(t, uint64(3), r)
-	r = valueHelp.asUint64(int8(3))
-	assert.Equal(t, uint64(3), r)
-	r = valueHelp.asUint64(uint8(3))
-	assert.Equal(t, uint64(3), r)
-	r = valueHelp.asUint64(int16(3))
-	assert.Equal(t, uint64(3), r)
-	r = valueHelp.asUint64(uint16(3))
-	assert.Equal(t, uint64(3), r)
-	r = valueHelp.asUint64(int32(3))
-	assert.Equal(t, uint64(3), r)
-	r = valueHelp.asUint64(uint32(3))
-	assert.Equal(t, uint64(3), r)
-	r = valueHelp.asUint64(int64(3))
-	assert.Equal(t, uint64(3), r)
-	r = valueHelp.asUint64(uint64(3))
-	assert.Equal(t, uint64(3), r)
-	r = valueHelp.asUint64(float32(3))
-	assert.Equal(t, uint64(3), r)
-	r = valueHelp.asUint64(float64(3))
-	assert.Equal(t, uint64(3), r)
+	for _, v := range integerFactory(3) {
+		assert.Equal(t, uint64(3), valueHelp.asUint64(v))
+	}
 
 	// Non numeric
-	//assert.PanicsWithValue(t, "Non numeric value in asUint64()", func() {
-	//	valueHelp.asUint64("123")
-	//})
 	if assert.NotPanics(t, func() {
 		valueHelp.asUint64("123")
 	}) {
@@ -109,58 +74,15 @@ func TestHelpers_asUint64(t *testing.T) {
 }
 
 // Test cases in private method asFloat64()
-// including expected panic() cases
 func TestHelpers_asFloat64(t *testing.T) {
-	var r float64
-	r = valueHelp.asFloat64(int(3))
-	assert.Equal(t, float64(3), r)
-	r = valueHelp.asFloat64(uint(3))
-	assert.Equal(t, float64(3), r)
-	r = valueHelp.asFloat64(int8(3))
-	assert.Equal(t, float64(3), r)
-	r = valueHelp.asFloat64(uint8(3))
-	assert.Equal(t, float64(3), r)
-	r = valueHelp.asFloat64(int16(3))
-	assert.Equal(t, float64(3), r)
-	r = valueHelp.asFloat64(uint16(3))
-	assert.Equal(t, float64(3), r)
-	r = valueHelp.asFloat64(int32(3))
-	assert.Equal(t, float64(3), r)
-	r = valueHelp.asFloat64(uint32(3))
-	assert.Equal(t, float64(3), r)
-	r = valueHelp.asFloat64(int64(3))
-	assert.Equal(t, float64(3), r)
-	r = valueHelp.asFloat64(uint64(3))
-	assert.Equal(t, float64(3), r)
-	r = valueHelp.asFloat64(float32(3))
-	assert.Equal(t, float64(3), r)
-	r = valueHelp.asFloat64(float64(3))
-	assert.Equal(t, float64(3), r)
+	for _, v := range integerFactory(3) {
+		assert.Equal(t, float64(3), valueHelp.asFloat64(v))
+	}
 
 	// Non numeric
-	//assert.PanicsWithValue(t, "Non numeric value in asFloat64()", func() {
-	//	valueHelp.asFloat64("123")
-	//})
 	if assert.NotPanics(t, func() {
 		valueHelp.asFloat64("123")
 	}) {
 		assert.Equal(t, valueHelp.asFloat64("123"), (float64)(0))
 	}
 }
-
-/* Deprecated helper method:
-func TestHelpers_ConvertToFloatEdgeCases(t *testing.T) {
-	v := numberValidator{}
-	// convert
-	assert.Equal(t, float64(12.5), v.convertToFloat(float32(12.5)))
-	assert.Equal(t, float64(12.5), v.convertToFloat(float64(12.5)))
-	assert.Equal(t, float64(12), v.convertToFloat(int(12)))
-	assert.Equal(t, float64(12), v.convertToFloat(int32(12)))
-	assert.Equal(t, float64(12), v.convertToFloat(int64(12)))
-
-	// does not convert
-	assert.Equal(t, float64(0), v.convertToFloat("12"))
-	// overflow : silent loss of info - ok (9.223372036854776e+18)
-	assert.NotEqual(t, float64(0), v.convertToFloat(int64(math.MaxInt64)))
-}
-*/

--- a/items_validator_test.go
+++ b/items_validator_test.go
@@ -17,6 +17,9 @@ package validate
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-openapi/errors"
@@ -25,23 +28,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type email struct {
-	Address string
-}
+var (
+	// PetStore20 json doc for swagger 2.0 pet store
+	PetStore20 string
 
-type paramFactory func(string) *spec.Parameter
-
-var paramFactories = []paramFactory{
-	spec.QueryParam,
-	spec.HeaderParam,
-	spec.PathParam,
-	spec.FormDataParam,
-}
-
-var stringItems = new(spec.Items)
+	// PetStoreJSONMessage json raw message for Petstore20
+	PetStoreJSONMessage json.RawMessage
+)
 
 func init() {
-	stringItems.Type = "string"
+	petstoreFixture := filepath.Join("fixtures", "petstore", "swagger.json")
+	petstore, err := ioutil.ReadFile(petstoreFixture)
+	if err != nil {
+		log.Fatalf("could not initialize fixture: %s: %v", petstoreFixture, err)
+	}
+	PetStoreJSONMessage = json.RawMessage(petstore)
+	PetStore20 = string(petstore)
+}
+
+func stringItems() *spec.Items {
+	return spec.NewItems().Typed(stringType, "")
 }
 
 func requiredError(param *spec.Parameter) *errors.Validation {
@@ -60,9 +66,11 @@ func multipleOfErrorItems(path, in string, items *spec.Items) *errors.Validation
 	return errors.NotMultipleOf(path, in, *items.MultipleOf)
 }
 
+/*
 func requiredErrorItems(path, in string) *errors.Validation {
 	return errors.Required(path, in)
 }
+*/
 
 func maxLengthErrorItems(path, in string, items *spec.Items) *errors.Validation {
 	return errors.TooLong(path, in, *items.MaxLength)
@@ -159,7 +167,7 @@ func TestNumberItemsValidation(t *testing.T) {
 }
 
 func TestStringItemsValidation(t *testing.T) {
-	items := spec.NewItems().WithMinLength(3).WithMaxLength(5).WithPattern(`^[a-z]+$`).Typed("string", "")
+	items := spec.NewItems().WithMinLength(3).WithMaxLength(5).WithPattern(`^[a-z]+$`).Typed(stringType, "")
 	items.WithEnum("aaa", "bbb", "ccc")
 	parent := spec.QueryParam("tags").CollectionOf(items, "")
 	path := parent.Name + ".1"
@@ -196,7 +204,7 @@ func TestStringItemsValidation(t *testing.T) {
 }
 
 func TestArrayItemsValidation(t *testing.T) {
-	items := spec.NewItems().CollectionOf(stringItems, "").WithMinItems(1).WithMaxItems(5).UniqueValues()
+	items := spec.NewItems().CollectionOf(stringItems(), "").WithMinItems(1).WithMaxItems(5).UniqueValues()
 	items.WithEnum("aaa", "bbb", "ccc")
 	parent := spec.QueryParam("tags").CollectionOf(items, "")
 	path := parent.Name + ".1"
@@ -221,7 +229,7 @@ func TestArrayItemsValidation(t *testing.T) {
 	assert.EqualError(t, enumFailItems(path, validator.in, items, []string{"a", "b", "c"}), err.Errors[0].Error())
 
 	// Items
-	strItems := spec.NewItems().WithMinLength(3).WithMaxLength(5).WithPattern(`^[a-z]+$`).Typed("string", "")
+	strItems := spec.NewItems().WithMinLength(3).WithMaxLength(5).WithPattern(`^[a-z]+$`).Typed(stringType, "")
 	items = spec.NewItems().CollectionOf(strItems, "").WithMinItems(1).WithMaxItems(5).UniqueValues()
 	validator = newItemsValidator(parent.Name, parent.In, items, parent, strfmt.Default)
 
@@ -229,289 +237,3 @@ func TestArrayItemsValidation(t *testing.T) {
 	assert.True(t, err.HasErrors())
 	assert.EqualError(t, minLengthErrorItems(path+".0", parent.In, strItems), err.Errors[0].Error())
 }
-
-// PetStoreJSONMessage json raw message for Petstore20
-var PetStoreJSONMessage = json.RawMessage([]byte(PetStore20))
-
-// PetStore20 json doc for swagger 2.0 pet store
-const PetStore20 = `{
-  "swagger": "2.0",
-  "info": {
-    "version": "1.0.0",
-    "title": "Swagger Petstore",
-    "contact": {
-      "name": "Wordnik API Team",
-      "url": "http://developer.wordnik.com"
-    },
-    "license": {
-      "name": "Creative Commons 4.0 International",
-      "url": "http://creativecommons.org/licenses/by/4.0/"
-    }
-  },
-  "host": "petstore.swagger.wordnik.com",
-  "basePath": "/api",
-  "schemes": [
-    "http"
-  ],
-  "paths": {
-    "/pets": {
-      "get": {
-        "security": [
-          {
-            "basic": []
-          }
-        ],
-        "tags": [ "Pet Operations" ],
-        "operationId": "getAllPets",
-        "parameters": [
-          {
-            "name": "status",
-            "in": "query",
-            "description": "The status to filter by",
-            "type": "string"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The maximum number of results to return",
-            "type": "integer",
-						"format": "int64"
-          }
-        ],
-        "summary": "Finds all pets in the system",
-        "responses": {
-          "200": {
-            "description": "Pet response",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Pet"
-              }
-            }
-          },
-          "default": {
-            "description": "Unexpected error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      },
-      "post": {
-        "security": [
-          {
-            "basic": []
-          }
-        ],
-        "tags": [ "Pet Operations" ],
-        "operationId": "createPet",
-        "summary": "Creates a new pet",
-        "consumes": ["application/x-yaml"],
-        "produces": ["application/x-yaml"],
-        "parameters": [
-          {
-            "name": "pet",
-            "in": "body",
-            "description": "The Pet to create",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/newPet"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Created Pet response",
-            "schema": {
-              "$ref": "#/definitions/Pet"
-            }
-          },
-          "default": {
-            "description": "Unexpected error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
-    "/pets/{id}": {
-      "delete": {
-        "security": [
-          {
-            "apiKey": []
-          }
-        ],
-        "description": "Deletes the Pet by id",
-        "operationId": "deletePet",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of pet to delete",
-            "required": true,
-            "type": "integer",
-            "format": "int64"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "pet deleted"
-          },
-          "default": {
-            "description": "unexpected error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [ "Pet Operations" ],
-        "operationId": "getPetById",
-        "summary": "Finds the pet by id",
-        "responses": {
-          "200": {
-            "description": "Pet response",
-            "schema": {
-              "$ref": "#/definitions/Pet"
-            }
-          },
-          "default": {
-            "description": "Unexpected error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      },
-      "parameters": [
-        {
-          "name": "id",
-          "in": "path",
-          "description": "ID of pet",
-          "required": true,
-          "type": "integer",
-          "format": "int64"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Category": {
-      "id": "Category",
-      "properties": {
-        "id": {
-          "format": "int64",
-          "type": "integer"
-        },
-        "name": {
-          "type": "string"
-        }
-      }
-    },
-    "Pet": {
-      "id": "Pet",
-      "properties": {
-        "category": {
-          "$ref": "#/definitions/Category"
-        },
-        "id": {
-          "description": "unique identifier for the pet",
-          "format": "int64",
-          "maximum": 100.0,
-          "minimum": 0.0,
-          "type": "integer"
-        },
-        "name": {
-          "type": "string"
-        },
-        "photoUrls": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "status": {
-          "description": "pet status in the store",
-          "enum": [
-            "available",
-            "pending",
-            "sold"
-          ],
-          "type": "string"
-        },
-        "tags": {
-          "items": {
-            "$ref": "#/definitions/Tag"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "id",
-        "name"
-      ]
-    },
-    "newPet": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Pet"
-        },
-        {
-          "required": [
-            "name"
-          ]
-        }
-      ]
-    },
-    "Tag": {
-      "id": "Tag",
-      "properties": {
-        "id": {
-          "format": "int64",
-          "type": "integer"
-        },
-        "name": {
-          "type": "string"
-        }
-      }
-    },
-    "Error": {
-      "required": [
-        "code",
-        "message"
-      ],
-      "properties": {
-        "code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        }
-      }
-    }
-  },
-  "consumes": [
-    "application/json",
-    "application/xml"
-  ],
-  "produces": [
-    "application/json",
-    "application/xml",
-    "text/plain",
-    "text/html"
-  ],
-  "securityDefinitions": {
-    "basic": {
-      "type": "basic"
-    },
-    "apiKey": {
-      "type": "apiKey",
-      "in": "header",
-      "name": "X-API-KEY"
-    }
-  }
-}
-`

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -22,12 +22,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Data structure for jsonschema-suite fixtures
@@ -41,103 +41,59 @@ type schemaTestT struct {
 	}
 }
 
-type schemasTestT struct {
-	Schema  *spec.Schema `json:"schema"`
-	Valid   interface{}  `json:"valid"`
-	Invalid interface{}  `json:"invalid"`
-}
-
 var jsonSchemaFixturesPath = filepath.Join("fixtures", "jsonschema_suite")
 var schemaFixturesPath = filepath.Join("fixtures", "schemas")
 var formatFixturesPath = filepath.Join("fixtures", "formats")
 
-var ints = []interface{}{
-	1,
-	int8(1),
-	int16(1),
-	int(1),
-	int32(1),
-	int64(1),
-	uint8(1),
-	uint16(1),
-	uint(1),
-	uint32(1),
-	uint64(1),
-	5.0,
-	float32(5.0),
-	float64(5.0),
-}
-
-var notInts = []interface{}{
-	5.1,
-	float32(5.1),
-	float64(5.1),
-}
-
-var notNumbers = []interface{}{
-	map[string]string{},
-	struct{}{},
-	time.Time{},
-	"yada",
-}
-
-var enabled = []string{
+func enabled() []string {
 	// Standard fixtures from JSON schema suite
-	"minLength",
-	"maxLength",
-	"pattern",
-	"type",
-	"minimum",
-	"maximum",
-	"multipleOf",
-	"enum",
-	"default",
-	"dependencies",
-	"items",
-	"maxItems",
-	"maxProperties",
-	"minItems",
-	"minProperties",
-	"patternProperties",
-	"required",
-	"additionalItems",
-	"uniqueItems",
-	"properties",
-	"additionalProperties",
-	"allOf",
-	"not",
-	"oneOf",
-	"anyOf",
-	"ref",
-	"definitions",
-	"refRemote",
-	"format",
+	return []string{
+		"minLength",
+		"maxLength",
+		"pattern",
+		"type",
+		"minimum",
+		"maximum",
+		"multipleOf",
+		"enum",
+		"default",
+		"dependencies",
+		"items",
+		"maxItems",
+		"maxProperties",
+		"minItems",
+		"minProperties",
+		"patternProperties",
+		"required",
+		"additionalItems",
+		"uniqueItems",
+		"properties",
+		"additionalProperties",
+		"allOf",
+		"not",
+		"oneOf",
+		"anyOf",
+		"ref",
+		"definitions",
+		"refRemote",
+		"format",
+	}
 }
 
 var optionalFixtures = []string{
-// Optional fixtures from JSON schema suite
-//"zeroTerminatedFloats",
-//"format",	/* error on strict URI formatting */
-//"bignum",
-//"ecmascript-regex",
+	// Optional fixtures from JSON schema suite: at the moment, these are disabled
+	//"zeroTerminatedFloats",
+	//"format",	/* error on strict URI formatting */
+	//"bignum",
+	//"ecmascript-regex",
 }
 
 var extendedFixtures = []string{
 	"extended-format",
 }
 
-type noopResCache struct {
-}
-
-func (n *noopResCache) Get(key string) (interface{}, bool) {
-	return nil, false
-}
-func (n *noopResCache) Set(string, interface{}) {
-
-}
-
 func isEnabled(nm string) bool {
-	return swag.ContainsStringsCI(enabled, nm)
+	return swag.ContainsStringsCI(enabled(), nm)
 }
 
 func isOptionalEnabled(nm string) bool {
@@ -167,46 +123,17 @@ func TestJSONSchemaSuite(t *testing.T) {
 			continue
 		}
 		fileName := f.Name()
-		specName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
-		if isEnabled(specName) {
+		t.Run(fileName, func(t *testing.T) {
+			t.Parallel()
+			specName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+			if !isEnabled(specName) {
+				t.Logf("WARNING: fixture from jsonschema-test-suite not enabled: %s", specName)
+				return
+			}
 			t.Log("Running " + specName)
 			b, _ := ioutil.ReadFile(filepath.Join(jsonSchemaFixturesPath, fileName))
-
-			var testDescriptions []schemaTestT
-			json.Unmarshal(b, &testDescriptions)
-
-			for _, testDescription := range testDescriptions {
-				var err error
-				b, _ := testDescription.Schema.MarshalJSON()
-				tmpFile, err := ioutil.TempFile(os.TempDir(), "validate-test")
-				assert.NoError(t, err)
-				tmpFile.Write(b)
-				tmpFile.Close()
-				opts := &spec.ExpandOptions{
-					RelativeBase:    tmpFile.Name(),
-					SkipSchemas:     false,
-					ContinueOnError: false,
-				}
-				err = spec.ExpandSchemaWithBasePath(testDescription.Schema, nil, opts)
-
-				if assert.NoError(t, err, testDescription.Description+" should expand cleanly") {
-					validator := NewSchemaValidator(testDescription.Schema, nil, "data", strfmt.Default)
-					for _, test := range testDescription.Tests {
-						result := validator.Validate(test.Data)
-						assert.NotNil(t, result, test.Description+" should validate")
-
-						if test.Valid {
-							assert.Empty(t, result.Errors, test.Description+" should not have errors")
-						} else {
-							assert.NotEmpty(t, result.Errors, test.Description+" should have errors")
-						}
-					}
-				}
-				os.Remove(tmpFile.Name())
-			}
-		} else {
-			t.Logf("WARNING: fixture from jsonschema-test-suite not enabled: %s", specName)
-		}
+			doTestSchemaSuite(t, b)
+		})
 	}
 }
 
@@ -221,30 +148,21 @@ func TestSchemaFixtures(t *testing.T) {
 			continue
 		}
 		fileName := f.Name()
-		specName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+		t.Run(fileName, func(t *testing.T) {
+			t.Parallel()
+			specName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+			t.Log("Running " + specName)
+			b, _ := ioutil.ReadFile(filepath.Join(schemaFixturesPath, fileName))
+			doTestSchemaSuite(t, b)
+		})
+	}
+}
 
-		t.Log("Running " + specName)
-		b, _ := ioutil.ReadFile(filepath.Join(schemaFixturesPath, fileName))
-
-		var testDescriptions []schemasTestT
-		json.Unmarshal(b, &testDescriptions)
-
-		for _, testDescription := range testDescriptions {
-
-			err := spec.ExpandSchema(testDescription.Schema, nil, nil /*new(noopResCache)*/)
-			if assert.NoError(t, err) {
-
-				validator := NewSchemaValidator(testDescription.Schema, nil, "data", strfmt.Default)
-				valid := validator.Validate(testDescription.Valid)
-				if assert.NotNil(t, valid, specName+" should validate") {
-					assert.Empty(t, valid.Errors, specName+".valid should not have errors")
-				}
-				invalid := validator.Validate(testDescription.Invalid)
-				if assert.NotNil(t, invalid, specName+" should validate") {
-					assert.NotEmpty(t, invalid.Errors, specName+".invalid should have errors")
-				}
-			}
-		}
+func expandOpts(base string) *spec.ExpandOptions {
+	return &spec.ExpandOptions{
+		RelativeBase:    base,
+		SkipSchemas:     false,
+		ContinueOnError: false,
 	}
 }
 
@@ -260,46 +178,17 @@ func TestOptionalJSONSchemaSuite(t *testing.T) {
 			continue
 		}
 		fileName := f.Name()
-		specName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
-		if isOptionalEnabled(specName) {
+		t.Run(fileName, func(t *testing.T) {
+			t.Parallel()
+			specName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+			if !isOptionalEnabled(specName) {
+				t.Logf("INFO: fixture from jsonschema-test-suite [optional] not enabled: %s", specName)
+				return
+			}
 			t.Log("Running [optional] " + specName)
 			b, _ := ioutil.ReadFile(filepath.Join(jsonOptionalSchemaFixturesPath, fileName))
-
-			var testDescriptions []schemaTestT
-			json.Unmarshal(b, &testDescriptions)
-
-			for _, testDescription := range testDescriptions {
-				var err error
-				b, _ := testDescription.Schema.MarshalJSON()
-				tmpFile, err := ioutil.TempFile(os.TempDir(), "validate-test")
-				assert.NoError(t, err)
-				tmpFile.Write(b)
-				tmpFile.Close()
-				opts := &spec.ExpandOptions{
-					RelativeBase:    tmpFile.Name(),
-					SkipSchemas:     false,
-					ContinueOnError: false,
-				}
-				err = spec.ExpandSchemaWithBasePath(testDescription.Schema, nil, opts)
-
-				if assert.NoError(t, err, testDescription.Description+" should expand cleanly") {
-					validator := NewSchemaValidator(testDescription.Schema, nil, "data", strfmt.Default)
-					for _, test := range testDescription.Tests {
-						result := validator.Validate(test.Data)
-						assert.NotNil(t, result, test.Description+" should validate")
-
-						if test.Valid {
-							assert.Empty(t, result.Errors, test.Description+" should not have errors")
-						} else {
-							assert.NotEmpty(t, result.Errors, test.Description+" should have errors")
-						}
-					}
-				}
-				os.Remove(tmpFile.Name())
-			}
-		} else {
-			t.Logf("INFO: fixture from jsonschema-test-suite [optional] not enabled: %s", specName)
-		}
+			doTestSchemaSuite(t, b)
+		})
 	}
 }
 
@@ -316,48 +205,46 @@ func TestFormat_JSONSchemaExtended(t *testing.T) {
 			continue
 		}
 		fileName := f.Name()
-		specName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
-		if isExtendedEnabled(specName) {
+		t.Run(fileName, func(t *testing.T) {
+			t.Parallel()
+			specName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+			if !isExtendedEnabled(specName) {
+				t.Logf("INFO: fixture from extended tests suite [formats] not enabled: %s", specName)
+				return
+			}
 			t.Log("Running [extended formats] " + specName)
 			b, _ := ioutil.ReadFile(filepath.Join(jsonFormatSchemaFixturesPath, fileName))
+			doTestSchemaSuite(t, b)
+		})
+	}
+}
 
-			var testDescriptions []schemaTestT
-			json.Unmarshal(b, &testDescriptions)
+func doTestSchemaSuite(t *testing.T, doc []byte) {
+	// run a test formatted as per jsonschema-test-suite
+	var testDescriptions []schemaTestT
+	eru := json.Unmarshal(doc, &testDescriptions)
+	require.NoError(t, eru)
 
-			for _, testDescription := range testDescriptions {
-				var err error
+	for _, testDescription := range testDescriptions {
+		b, _ := testDescription.Schema.MarshalJSON()
+		tmpFile, err := ioutil.TempFile(os.TempDir(), "validate-test")
+		assert.NoError(t, err)
+		_, _ = tmpFile.Write(b)
+		tmpFile.Close()
+		defer func() { _ = os.Remove(tmpFile.Name()) }()
+		err = spec.ExpandSchemaWithBasePath(testDescription.Schema, nil, expandOpts(tmpFile.Name()))
+		require.NoError(t, err, testDescription.Description+" should expand cleanly")
 
-				// 1. Compile schema
-				b, _ := testDescription.Schema.MarshalJSON()
-				tmpFile, err := ioutil.TempFile(os.TempDir(), "validate-test")
-				assert.NoError(t, err)
-				tmpFile.Write(b)
-				tmpFile.Close()
-				opts := &spec.ExpandOptions{
-					RelativeBase:    tmpFile.Name(),
-					SkipSchemas:     false,
-					ContinueOnError: false,
-				}
-				err = spec.ExpandSchemaWithBasePath(testDescription.Schema, nil, opts)
+		validator := NewSchemaValidator(testDescription.Schema, nil, "data", strfmt.Default)
+		for _, test := range testDescription.Tests {
+			result := validator.Validate(test.Data)
+			assert.NotNil(t, result, test.Description+" should validate")
 
-				if assert.NoError(t, err, testDescription.Description+" should expand cleanly") {
-					validator := NewSchemaValidator(testDescription.Schema, nil, "data", strfmt.Default)
-					for _, test := range testDescription.Tests {
-						// 2. Validates raw JSON values against schema
-						result := validator.Validate(test.Data)
-						assert.NotNil(t, result, test.Description+" should validate")
-
-						if test.Valid {
-							assert.Emptyf(t, result.Errors, test.Description+" should not have errors but got: %v", result.Errors)
-						} else {
-							assert.NotEmpty(t, result.Errors, test.Description+" should have errors")
-						}
-					}
-				}
-				os.Remove(tmpFile.Name())
+			if test.Valid {
+				assert.Empty(t, result.Errors, test.Description+" should not have errors")
+			} else {
+				assert.NotEmpty(t, result.Errors, test.Description+" should have errors")
 			}
-		} else {
-			t.Logf("INFO: fixture from extended tests suite [formats] not enabled: %s", specName)
 		}
 	}
 }

--- a/object_validator_test.go
+++ b/object_validator_test.go
@@ -50,10 +50,9 @@ func TestItemsMustBeTypeArray(t *testing.T) {
 		"type":  "object",
 		"items": "dummy",
 	}
-	ov.Options.DisableObjectArrayTypeCheck = true
 	expectAllValid(t, ov, dataValid, dataInvalid)
 
-	ov.Options.DisableObjectArrayTypeCheck = false
+	ov.Options.EnableObjectArrayTypeCheck = true
 	expectOnlyInvalid(t, ov, dataValid, dataInvalid)
 }
 
@@ -63,10 +62,9 @@ func TestItemsMustHaveType(t *testing.T) {
 	dataInvalid := map[string]interface{}{
 		"items": "dummy",
 	}
-	ov.Options.DisableObjectArrayTypeCheck = true
 	expectAllValid(t, ov, dataValid, dataInvalid)
 
-	ov.Options.DisableObjectArrayTypeCheck = false
+	ov.Options.EnableObjectArrayTypeCheck = true
 	expectOnlyInvalid(t, ov, dataValid, dataInvalid)
 }
 
@@ -77,6 +75,9 @@ func TestTypeArrayMustHaveItems(t *testing.T) {
 		"type": "array",
 		"key":  "dummy",
 	}
+	expectAllValid(t, ov, dataValid, dataInvalid)
+
+	ov.Options.EnableArrayMustHaveItemsCheck = true
 	expectOnlyInvalid(t, ov, dataValid, dataInvalid)
 }
 

--- a/parameter_validator_test.go
+++ b/parameter_validator_test.go
@@ -141,7 +141,7 @@ func enumFail(param *spec.Parameter, data interface{}) *errors.Validation {
 }
 
 func TestStringParameterValidation(t *testing.T) {
-	nameParam := spec.QueryParam("name").AsRequired().WithMinLength(3).WithMaxLength(5).WithPattern(`^[a-z]+$`).Typed("string", "")
+	nameParam := spec.QueryParam("name").AsRequired().WithMinLength(3).WithMaxLength(5).WithPattern(`^[a-z]+$`).Typed(stringType, "")
 	nameParam.WithEnum("aaa", "bbb", "ccc")
 	validator := NewParamValidator(nameParam, strfmt.Default)
 
@@ -190,7 +190,7 @@ func duplicatesError(param *spec.Parameter) *errors.Validation {
 }
 
 func TestArrayParameterValidation(t *testing.T) {
-	tagsParam := spec.QueryParam("tags").CollectionOf(stringItems, "").WithMinItems(1).WithMaxItems(5).UniqueValues()
+	tagsParam := spec.QueryParam("tags").CollectionOf(stringItems(), "").WithMinItems(1).WithMaxItems(5).UniqueValues()
 	tagsParam.WithEnum([]string{"a", "a", "a"}, []string{"b", "b", "b"}, []string{"c", "c", "c"})
 	validator := NewParamValidator(tagsParam, strfmt.Default)
 
@@ -213,7 +213,7 @@ func TestArrayParameterValidation(t *testing.T) {
 	assert.EqualError(t, enumFail(tagsParam, []string{"a", "b", "c"}), err.Errors[0].Error())
 
 	// Items
-	strItems := spec.NewItems().WithMinLength(3).WithMaxLength(5).WithPattern(`^[a-z]+$`).Typed("string", "")
+	strItems := spec.NewItems().WithMinLength(3).WithMaxLength(5).WithPattern(`^[a-z]+$`).Typed(stringType, "")
 	tagsParam = spec.QueryParam("tags").CollectionOf(strItems, "").WithMinItems(1).WithMaxItems(5).UniqueValues()
 	validator = NewParamValidator(tagsParam, strfmt.Default)
 	err = validator.Validate([]string{"aa", "bbb", "ccc"})

--- a/result_test.go
+++ b/result_test.go
@@ -24,16 +24,16 @@ import (
 // Test AddError() uniqueness
 func TestResult_AddError(t *testing.T) {
 	r := Result{}
-	r.AddErrors(fmt.Errorf("One error"))
-	r.AddErrors(fmt.Errorf("Another error"))
-	r.AddErrors(fmt.Errorf("One error"))
-	r.AddErrors(fmt.Errorf("One error"))
-	r.AddErrors(fmt.Errorf("One error"))
-	r.AddErrors(fmt.Errorf("One error"), fmt.Errorf("Another error"))
+	r.AddErrors(fmt.Errorf("one error"))
+	r.AddErrors(fmt.Errorf("another error"))
+	r.AddErrors(fmt.Errorf("one error"))
+	r.AddErrors(fmt.Errorf("one error"))
+	r.AddErrors(fmt.Errorf("one error"))
+	r.AddErrors(fmt.Errorf("one error"), fmt.Errorf("another error"))
 
 	assert.Len(t, r.Errors, 2)
-	assert.Contains(t, r.Errors, fmt.Errorf("One error"))
-	assert.Contains(t, r.Errors, fmt.Errorf("Another error"))
+	assert.Contains(t, r.Errors, fmt.Errorf("one error"))
+	assert.Contains(t, r.Errors, fmt.Errorf("another error"))
 }
 
 func TestResult_AddNilError(t *testing.T) {
@@ -41,26 +41,26 @@ func TestResult_AddNilError(t *testing.T) {
 	r.AddErrors(nil)
 	assert.Len(t, r.Errors, 0)
 
-	errArray := []error{fmt.Errorf("One Error"), nil, fmt.Errorf("Another error")}
+	errArray := []error{fmt.Errorf("one Error"), nil, fmt.Errorf("another error")}
 	r.AddErrors(errArray...)
 	assert.Len(t, r.Errors, 2)
 }
 
 func TestResult_AddWarnings(t *testing.T) {
 	r := Result{}
-	r.AddErrors(fmt.Errorf("One Error"))
+	r.AddErrors(fmt.Errorf("one Error"))
 	assert.Len(t, r.Errors, 1)
 	assert.Len(t, r.Warnings, 0)
 
-	r.AddWarnings(fmt.Errorf("One Warning"))
+	r.AddWarnings(fmt.Errorf("one Warning"))
 	assert.Len(t, r.Errors, 1)
 	assert.Len(t, r.Warnings, 1)
 }
 
 func TestResult_Merge(t *testing.T) {
 	r := Result{}
-	r.AddErrors(fmt.Errorf("One Error"))
-	r.AddWarnings(fmt.Errorf("One Warning"))
+	r.AddErrors(fmt.Errorf("one Error"))
+	r.AddWarnings(fmt.Errorf("one Warning"))
 	r.Inc()
 	assert.Len(t, r.Errors, 1)
 	assert.Len(t, r.Warnings, 1)
@@ -68,8 +68,8 @@ func TestResult_Merge(t *testing.T) {
 
 	// Merge with same
 	r2 := Result{}
-	r2.AddErrors(fmt.Errorf("One Error"))
-	r2.AddWarnings(fmt.Errorf("One Warning"))
+	r2.AddErrors(fmt.Errorf("one Error"))
+	r2.AddWarnings(fmt.Errorf("one Warning"))
 	r2.Inc()
 
 	r.Merge(&r2)
@@ -80,8 +80,8 @@ func TestResult_Merge(t *testing.T) {
 
 	// Merge with new
 	r3 := Result{}
-	r3.AddErrors(fmt.Errorf("New Error"))
-	r3.AddWarnings(fmt.Errorf("New Warning"))
+	r3.AddErrors(fmt.Errorf("new Error"))
+	r3.AddWarnings(fmt.Errorf("new Warning"))
 	r3.Inc()
 
 	r.Merge(&r3)
@@ -91,26 +91,31 @@ func TestResult_Merge(t *testing.T) {
 	assert.Equal(t, r.MatchCount, 3)
 }
 
-func TestResult_MergeAsErrors(t *testing.T) {
+func errorFixture() (Result, Result, Result) {
 	r := Result{}
-	r.AddErrors(fmt.Errorf("One Error"))
-	r.AddWarnings(fmt.Errorf("One Warning"))
+	r.AddErrors(fmt.Errorf("one Error"))
+	r.AddWarnings(fmt.Errorf("one Warning"))
 	r.Inc()
-	assert.Len(t, r.Errors, 1)
-	assert.Len(t, r.Warnings, 1)
-	assert.Equal(t, r.MatchCount, 1)
 
 	// same
 	r2 := Result{}
-	r2.AddErrors(fmt.Errorf("One Error"))
-	r2.AddWarnings(fmt.Errorf("One Warning"))
+	r2.AddErrors(fmt.Errorf("one Error"))
+	r2.AddWarnings(fmt.Errorf("one Warning"))
 	r2.Inc()
 
 	// new
 	r3 := Result{}
-	r3.AddErrors(fmt.Errorf("New Error"))
-	r3.AddWarnings(fmt.Errorf("New Warning"))
+	r3.AddErrors(fmt.Errorf("new Error"))
+	r3.AddWarnings(fmt.Errorf("new Warning"))
 	r3.Inc()
+	return r, r2, r3
+}
+
+func TestResult_MergeAsErrors(t *testing.T) {
+	r, r2, r3 := errorFixture()
+	assert.Len(t, r.Errors, 1)
+	assert.Len(t, r.Warnings, 1)
+	assert.Equal(t, r.MatchCount, 1)
 
 	r.MergeAsErrors(&r2, &r3)
 
@@ -120,25 +125,10 @@ func TestResult_MergeAsErrors(t *testing.T) {
 }
 
 func TestResult_MergeAsWarnings(t *testing.T) {
-	r := Result{}
-	r.AddErrors(fmt.Errorf("One Error"))
-	r.AddWarnings(fmt.Errorf("One Warning"))
-	r.Inc()
+	r, r2, r3 := errorFixture()
 	assert.Len(t, r.Errors, 1)
 	assert.Len(t, r.Warnings, 1)
 	assert.Equal(t, r.MatchCount, 1)
-
-	// same
-	r2 := Result{}
-	r2.AddErrors(fmt.Errorf("One Error"))
-	r2.AddWarnings(fmt.Errorf("One Warning"))
-	r2.Inc()
-
-	// new
-	r3 := Result{}
-	r3.AddErrors(fmt.Errorf("New Error"))
-	r3.AddWarnings(fmt.Errorf("New Warning"))
-	r3.Inc()
 
 	r.MergeAsWarnings(&r2, &r3)
 
@@ -153,11 +143,11 @@ func TestResult_IsValid(t *testing.T) {
 	assert.True(t, r.IsValid())
 	assert.False(t, r.HasErrors())
 
-	r.AddWarnings(fmt.Errorf("One Warning"))
+	r.AddWarnings(fmt.Errorf("one Warning"))
 	assert.True(t, r.IsValid())
 	assert.False(t, r.HasErrors())
 
-	r.AddErrors(fmt.Errorf("One Error"))
+	r.AddErrors(fmt.Errorf("one Error"))
 	assert.False(t, r.IsValid())
 	assert.True(t, r.HasErrors())
 }
@@ -167,10 +157,10 @@ func TestResult_HasWarnings(t *testing.T) {
 
 	assert.False(t, r.HasWarnings())
 
-	r.AddErrors(fmt.Errorf("One Error"))
+	r.AddErrors(fmt.Errorf("one Error"))
 	assert.False(t, r.HasWarnings())
 
-	r.AddWarnings(fmt.Errorf("One Warning"))
+	r.AddWarnings(fmt.Errorf("one Warning"))
 	assert.True(t, r.HasWarnings())
 }
 
@@ -180,10 +170,10 @@ func TestResult_HasErrorsOrWarnings(t *testing.T) {
 
 	assert.False(t, r.HasErrorsOrWarnings())
 
-	r.AddErrors(fmt.Errorf("One Error"))
+	r.AddErrors(fmt.Errorf("one Error"))
 	assert.True(t, r.HasErrorsOrWarnings())
 
-	r2.AddWarnings(fmt.Errorf("One Warning"))
+	r2.AddWarnings(fmt.Errorf("one Warning"))
 	assert.True(t, r2.HasErrorsOrWarnings())
 
 	r.Merge(&r2)
@@ -192,9 +182,9 @@ func TestResult_HasErrorsOrWarnings(t *testing.T) {
 
 func TestResult_keepRelevantErrors(t *testing.T) {
 	r := Result{}
-	r.AddErrors(fmt.Errorf("One Error"))
+	r.AddErrors(fmt.Errorf("one Error"))
 	r.AddErrors(fmt.Errorf("IMPORTANT!Another Error"))
-	r.AddWarnings(fmt.Errorf("One warning"))
+	r.AddWarnings(fmt.Errorf("one warning"))
 	r.AddWarnings(fmt.Errorf("IMPORTANT!Another warning"))
 	assert.Len(t, r.keepRelevantErrors().Errors, 1)
 	assert.Len(t, r.keepRelevantErrors().Warnings, 1)
@@ -203,13 +193,13 @@ func TestResult_keepRelevantErrors(t *testing.T) {
 func TestResult_AsError(t *testing.T) {
 	r := Result{}
 	assert.Nil(t, r.AsError())
-	r.AddErrors(fmt.Errorf("One Error"))
-	r.AddErrors(fmt.Errorf("Additional Error"))
+	r.AddErrors(fmt.Errorf("one Error"))
+	r.AddErrors(fmt.Errorf("additional Error"))
 	res := r.AsError()
 	if assert.NotNil(t, res) {
 		assert.Contains(t, res.Error(), "validation failure list:") // Expected from pkg errors
-		assert.Contains(t, res.Error(), "One Error")                // Expected from pkg errors
-		assert.Contains(t, res.Error(), "Additional Error")         // Expected from pkg errors
+		assert.Contains(t, res.Error(), "one Error")                // Expected from pkg errors
+		assert.Contains(t, res.Error(), "additional Error")         // Expected from pkg errors
 	}
 }
 

--- a/schema.go
+++ b/schema.go
@@ -39,14 +39,14 @@ type SchemaValidator struct {
 	validators   []valueValidator
 	Root         interface{}
 	KnownFormats strfmt.Registry
-	Options      *SchemaValidatorOptions
+	Options      SchemaValidatorOptions
 }
 
 // AgainstSchema validates the specified data against the provided schema, using a registry of supported formats.
 //
 // When no pre-parsed *spec.Schema structure is provided, it uses a JSON schema as default. See example.
-func AgainstSchema(schema *spec.Schema, data interface{}, formats strfmt.Registry) error {
-	res := NewSchemaValidator(schema, nil, "", formats).Validate(data)
+func AgainstSchema(schema *spec.Schema, data interface{}, formats strfmt.Registry, options ...Option) error {
+	res := NewSchemaValidator(schema, nil, "", formats, options...).Validate(data)
 	if res.HasErrors() {
 		return errors.CompositeValidationError(res.Errors...)
 	}
@@ -78,9 +78,9 @@ func NewSchemaValidator(schema *spec.Schema, rootSchema interface{}, root string
 		Schema:       schema,
 		Root:         rootSchema,
 		KnownFormats: formats,
-		Options:      &SchemaValidatorOptions{}}
+		Options:      SchemaValidatorOptions{}}
 	for _, o := range options {
-		o(s.Options)
+		o(&s.Options)
 	}
 	s.validators = []valueValidator{
 		s.typeValidator(),
@@ -202,6 +202,7 @@ func (s *SchemaValidator) sliceValidator() valueValidator {
 		Items:           s.Schema.Items,
 		Root:            s.Root,
 		KnownFormats:    s.KnownFormats,
+		Options:         s.Options,
 	}
 }
 
@@ -254,6 +255,6 @@ func (s *SchemaValidator) objectValidator() valueValidator {
 		PatternProperties:    s.Schema.PatternProperties,
 		Root:                 s.Root,
 		KnownFormats:         s.KnownFormats,
-		Options:              *s.Options,
+		Options:              s.Options,
 	}
 }

--- a/schema_option.go
+++ b/schema_option.go
@@ -16,22 +16,39 @@ package validate
 
 // SchemaValidatorOptions defines optional rules for schema validation
 type SchemaValidatorOptions struct {
-	DisableObjectArrayTypeCheck bool
+	EnableObjectArrayTypeCheck    bool
+	EnableArrayMustHaveItemsCheck bool
 }
 
 // Option sets optional rules for schema validation
 type Option func(*SchemaValidatorOptions)
 
-// DisableObjectArrayTypeCheck disables the swagger rule: an items must be in type: array
-func DisableObjectArrayTypeCheck(disable bool) Option {
+// EnableObjectArrayTypeCheck activates the swagger rule: an items must be in type: array
+func EnableObjectArrayTypeCheck(enable bool) Option {
 	return func(svo *SchemaValidatorOptions) {
-		svo.DisableObjectArrayTypeCheck = disable
+		svo.EnableObjectArrayTypeCheck = enable
+	}
+}
+
+// EnableArrayMustHaveItemsCheck activates the swagger rule: an array must have items defined
+func EnableArrayMustHaveItemsCheck(enable bool) Option {
+	return func(svo *SchemaValidatorOptions) {
+		svo.EnableArrayMustHaveItemsCheck = enable
+	}
+}
+
+// SwaggerSchema activates swagger schema validation rules
+func SwaggerSchema(enable bool) Option {
+	return func(svo *SchemaValidatorOptions) {
+		svo.EnableObjectArrayTypeCheck = enable
+		svo.EnableArrayMustHaveItemsCheck = enable
 	}
 }
 
 // Options returns current options
 func (svo SchemaValidatorOptions) Options() []Option {
 	return []Option{
-		DisableObjectArrayTypeCheck(svo.DisableObjectArrayTypeCheck),
+		EnableObjectArrayTypeCheck(svo.EnableObjectArrayTypeCheck),
+		EnableArrayMustHaveItemsCheck(svo.EnableArrayMustHaveItemsCheck),
 	}
 }

--- a/schema_option_test.go
+++ b/schema_option_test.go
@@ -18,11 +18,11 @@ import (
 	"testing"
 )
 
-func TestDisableObjectArrayTypeCheck(t *testing.T) {
+func TestEnableObjectArrayTypeCheck(t *testing.T) {
 	opts := &SchemaValidatorOptions{}
-	setter := DisableObjectArrayTypeCheck(true)
+	setter := EnableObjectArrayTypeCheck(true)
 	setter(opts)
-	if !opts.DisableObjectArrayTypeCheck {
-		t.Errorf("Expect 'DisableObjectArrayTypeCheck' is true, got false")
+	if !opts.EnableObjectArrayTypeCheck {
+		t.Errorf("Expect 'EnableObjectArrayTypeCheck' is true, got false")
 	}
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -206,12 +206,32 @@ func TestSchemaValidator_SchemaOptions(t *testing.T) {
 	assert.NoError(t, json.Unmarshal([]byte(inputJSON), &input))
 
 	// ok
-	s := NewSchemaValidator(schema, nil, "", strfmt.Default, DisableObjectArrayTypeCheck(true))
+	s := NewSchemaValidator(schema, nil, "", strfmt.Default, EnableObjectArrayTypeCheck(false))
 	result := s.Validate(input)
 	assert.True(t, result.IsValid())
 
 	// fail
-	s = NewSchemaValidator(schema, nil, "", strfmt.Default)
+	s = NewSchemaValidator(schema, nil, "", strfmt.Default, EnableObjectArrayTypeCheck(true))
 	result = s.Validate(input)
 	assert.False(t, result.IsValid())
+}
+
+func TestSchemaValidator_TypeArray_Issue83(t *testing.T) {
+	var schemaJSON = `
+{
+	"type": "object"
+}`
+
+	schema := new(spec.Schema)
+	require.NoError(t, json.Unmarshal([]byte(schemaJSON), schema))
+
+	var input map[string]interface{}
+	var inputJSON = `{"type": "array"}`
+
+	require.NoError(t, json.Unmarshal([]byte(inputJSON), &input))
+	// default behavior: jsonschema
+	assert.NoError(t, AgainstSchema(schema, input, strfmt.Default))
+
+	// swagger behavior
+	assert.Error(t, AgainstSchema(schema, input, strfmt.Default, SwaggerSchema(true)))
 }

--- a/spec.go
+++ b/spec.go
@@ -86,7 +86,7 @@ func (s *SpecValidator) Validate(data interface{}) (*Result, *Result) {
 	s.analyzer = analysis.New(sd.Spec())
 
 	// Swagger schema validator
-	schv := NewSchemaValidator(s.schema, nil, "", s.KnownFormats)
+	schv := NewSchemaValidator(s.schema, nil, "", s.KnownFormats, SwaggerSchema(true))
 	var obj interface{}
 
 	// Raw spec unmarshalling errors

--- a/spec_test.go
+++ b/spec_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Enable long running tests by using cmd line arg,
@@ -55,30 +56,51 @@ func skipNotify(t *testing.T) {
 	t.Log("To enable this long running test, use -args -enable-long in your go test command line")
 }
 
-func TestSpec_ExpandResponseLocalFile(t *testing.T) {
-	fp := filepath.Join("fixtures", "local_expansion", "spec.yaml")
-	doc, err := loads.Spec(fp)
-	if assert.NoError(t, err) {
-		if assert.NotNil(t, doc) {
-			validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-			res, _ := validator.Validate(doc)
-			assert.True(t, res.IsValid())
-			assert.Empty(t, res.Errors)
+func debugTest(t *testing.T, path string, res *Result) {
+	if DebugTest && t.Failed() {
+		verifiedErrors := verifiedTestErrors(res)
+		if len(verifiedErrors) > 0 {
+			t.Logf("DEVMODE:Returned error messages validating %s ", path)
+			for _, v := range verifiedErrors {
+				t.Logf("%s", v)
+			}
+		}
+		verifiedWarnings := verifiedTestWarnings(res)
+		if len(verifiedWarnings) > 0 {
+			t.Logf("DEVMODE: Returned warnings for %s:", path)
+			for _, e := range res.Warnings {
+				t.Logf("%v", e)
+			}
 		}
 	}
 }
 
-func TestSpec_ExpandResponseRecursive(t *testing.T) {
-	fp := filepath.Join("fixtures", "recursive_expansion", "spec.yaml")
-	doc, err := loads.Spec(fp)
-	if assert.NoError(t, err) {
-		if assert.NotNil(t, doc) {
-			validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-			res, _ := validator.Validate(doc)
-			assert.True(t, res.IsValid())
-			assert.Empty(t, res.Errors)
-		}
+func verifiedTestErrors(res *Result) []string {
+	verifiedErrors := make([]string, 0, 50)
+	for _, e := range res.Errors {
+		verifiedErrors = append(verifiedErrors, e.Error())
 	}
+	return verifiedErrors
+}
+
+func verifiedTestWarnings(res *Result) []string {
+	verifiedWarnings := make([]string, 0, 50)
+	for _, e := range res.Warnings {
+		verifiedWarnings = append(verifiedWarnings, e.Error())
+	}
+	return verifiedWarnings
+}
+
+func TestSpec_ExpandResponseLocalFile(t *testing.T) {
+	res, _ := loadAndValidate(t, filepath.Join("fixtures", "local_expansion", "spec.yaml"))
+	assert.True(t, res.IsValid())
+	assert.Empty(t, res.Errors)
+}
+
+func TestSpec_ExpandResponseRecursive(t *testing.T) {
+	res, _ := loadAndValidate(t, filepath.Join("fixtures", "recursive_expansion", "spec.yaml"))
+	assert.True(t, res.IsValid())
+	assert.Empty(t, res.Errors)
 }
 
 // Spec with no path
@@ -88,38 +110,22 @@ func TestSpec_Issue52(t *testing.T) {
 
 	// as json schema
 	var sch spec.Schema
-	if assert.NoError(t, json.Unmarshal(jstext, &sch)) {
-		validator := NewSchemaValidator(spec.MustLoadSwagger20Schema(), nil, "", strfmt.Default)
-		res := validator.Validate(&sch)
-		assert.False(t, res.IsValid())
-		assert.EqualError(t, res.Errors[0], ".paths in body is required")
-	}
+	require.NoError(t, json.Unmarshal(jstext, &sch))
+
+	schemaValidator := NewSchemaValidator(spec.MustLoadSwagger20Schema(), nil, "", strfmt.Default)
+	res := schemaValidator.Validate(&sch)
+	assert.False(t, res.IsValid())
+	assert.EqualError(t, res.Errors[0], ".paths in body is required")
 
 	// as swagger spec: path is set to nil
 	// Here, validation stops as paths is initialized to empty
-	doc, err := loads.Spec(fp)
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.False(t, res.IsValid())
-		assert.EqualError(t, res.Errors[0], ".paths in body is required")
-	}
-	// Here, validation continues, with invalid path from early checks as null.
-	// This provides an additional (hopefully more informative) message.
-	doc, err = loads.Spec(fp)
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		validator.SetContinueOnErrors(true)
-		res, _ := validator.Validate(doc)
-		assert.False(t, res.IsValid())
-		var verifiedErrors []string
-		for _, e := range res.Errors {
-			verifiedErrors = append(verifiedErrors, e.Error())
-		}
-		assert.Len(t, verifiedErrors, 2, "Unexpected number of error messages returned")
-		assert.Contains(t, verifiedErrors, ".paths in body is required")
-		assert.Contains(t, verifiedErrors, "spec has no valid path defined")
-	}
+	res, _ = loadAndValidate(t, fp)
+	assert.False(t, res.IsValid())
+
+	verifiedErrors := verifiedTestErrors(res)
+	assert.Len(t, verifiedErrors, 2, "Unexpected number of error messages returned")
+	assert.Contains(t, verifiedErrors, ".paths in body is required")
+	assert.Contains(t, verifiedErrors, "spec has no valid path defined")
 }
 
 func TestSpec_Issue53(t *testing.T) {
@@ -128,22 +134,17 @@ func TestSpec_Issue53(t *testing.T) {
 
 	// as json schema
 	var sch spec.Schema
-	if assert.NoError(t, json.Unmarshal(jstext, &sch)) {
-		validator := NewSchemaValidator(spec.MustLoadSwagger20Schema(), nil, "", strfmt.Default)
-		res := validator.Validate(&sch)
-		assert.False(t, res.IsValid())
-		assert.EqualError(t, res.Errors[0], ".swagger in body is required")
-	}
+	require.NoError(t, json.Unmarshal(jstext, &sch))
+
+	schemaValidator := NewSchemaValidator(spec.MustLoadSwagger20Schema(), nil, "", strfmt.Default)
+	res := schemaValidator.Validate(&sch)
+	assert.False(t, res.IsValid())
+	assert.EqualError(t, res.Errors[0], ".swagger in body is required")
 
 	// as swagger despec
-	doc, err := loads.Spec(fp)
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		if assert.False(t, res.IsValid()) {
-			assert.EqualError(t, res.Errors[0], ".swagger in body is required")
-		}
-	}
+	res, _ = loadAndValidate(t, fp, false)
+	require.False(t, res.IsValid())
+	assert.EqualError(t, res.Errors[0], ".swagger in body is required")
 }
 
 func TestSpec_Issue62(t *testing.T) {
@@ -151,120 +152,61 @@ func TestSpec_Issue62(t *testing.T) {
 
 	// as swagger spec
 	doc, err := loads.Spec(fp)
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.NotEmpty(t, res.Errors)
-		assert.True(t, res.HasErrors())
-	}
+	require.NoError(t, err)
+
+	validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
+	res, _ := validator.Validate(doc)
+	assert.NotEmpty(t, res.Errors)
+	assert.True(t, res.HasErrors())
 }
 
 func TestSpec_Issue63(t *testing.T) {
-	fp := filepath.Join("fixtures", "bugs", "63", "swagger.json")
-
-	// as swagger spec
-	doc, err := loads.Spec(fp)
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.True(t, res.IsValid())
-	}
+	res, _ := loadAndValidate(t, filepath.Join("fixtures", "bugs", "63", "swagger.json"))
+	assert.True(t, res.IsValid())
 }
 
 func TestSpec_Issue61_MultipleRefs(t *testing.T) {
-	fp := filepath.Join("fixtures", "bugs", "61", "multiple-refs.json")
-
-	// as swagger spec
-	doc, err := loads.Spec(fp)
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.Empty(t, res.Errors)
-		assert.True(t, res.IsValid())
-	}
+	res, _ := loadAndValidate(t, filepath.Join("fixtures", "bugs", "61", "multiple-refs.json"))
+	assert.Empty(t, res.Errors)
+	assert.True(t, res.IsValid())
 }
 
 func TestSpec_Issue61_ResolvedRef(t *testing.T) {
-	fp := filepath.Join("fixtures", "bugs", "61", "unresolved-ref-for-name.json")
-
-	// as swagger spec
-	doc, err := loads.Spec(fp)
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.Empty(t, res.Errors)
-		assert.True(t, res.IsValid())
-	}
+	res, _ := loadAndValidate(t, filepath.Join("fixtures", "bugs", "61", "unresolved-ref-for-name.json"))
+	assert.Empty(t, res.Errors)
+	assert.True(t, res.IsValid())
 }
 
 // No error with this one
 func TestSpec_Issue123(t *testing.T) {
-	path := "swagger.yml"
-	fp := filepath.Join("fixtures", "bugs", "123", path)
+	fp := filepath.Join("fixtures", "bugs", "123", "swagger.yml")
+	res, _ := loadAndValidate(t, fp)
+	assert.True(t, res.IsValid())
+	assert.Empty(t, res.Errors)
 
-	// as swagger spec
-	doc, err := loads.Spec(fp)
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.True(t, res.IsValid())
-
-		var verifiedErrors []string
-		for _, e := range res.Errors {
-			verifiedErrors = append(verifiedErrors, e.Error())
-		}
-		switch {
-		case strings.Contains(path, "swagger.yml"):
-			assert.Empty(t, verifiedErrors)
-		default:
-			t.Logf("Returned error messages: %v", verifiedErrors)
-			t.Fatal("fixture not tested. Please add assertions for messages")
-		}
-
-		if DebugTest && t.Failed() {
-			if len(verifiedErrors) > 0 {
-				t.Logf("DEVMODE: Returned error messages validating %s ", path)
-				for _, v := range verifiedErrors {
-					t.Logf("%s", v)
-				}
-			}
-		}
-	}
+	debugTest(t, fp, res)
 }
 
 func TestSpec_Issue6(t *testing.T) {
 	files, _ := filepath.Glob(filepath.Join("fixtures", "bugs", "6", "*.json"))
 	for _, path := range files {
 		t.Logf("Tested spec=%s", path)
-		doc, err := loads.Spec(path)
-		if assert.NoError(t, err) {
-			validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-			res, _ := validator.Validate(doc)
-			assert.False(t, res.IsValid())
+		res, _ := loadAndValidate(t, path)
+		assert.False(t, res.IsValid())
 
-			var verifiedErrors []string
-			for _, e := range res.Errors {
-				verifiedErrors = append(verifiedErrors, e.Error())
-			}
-			switch {
-			case strings.Contains(path, "empty-responses.json"):
-				assert.Contains(t, verifiedErrors, "\"paths./foo.get.responses\" must not validate the schema (not)")
-				assert.Contains(t, verifiedErrors, "paths./foo.get.responses in body should have at least 1 properties")
-			case strings.Contains(path, "no-responses.json"):
-				assert.Contains(t, verifiedErrors, "paths./foo.get.responses in body is required")
-			default:
-				t.Logf("Returned error messages: %v", verifiedErrors)
-				t.Fatal("fixture not tested. Please add assertions for messages")
-			}
-			if DebugTest && t.Failed() {
-				if len(verifiedErrors) > 0 {
-					t.Logf("DEVMODE:Returned error messages validating %s ", path)
-					for _, v := range verifiedErrors {
-						t.Logf("%s", v)
-					}
-				}
-			}
+		verifiedErrors := verifiedTestErrors(res)
+		switch {
+		case strings.Contains(path, "empty-responses.json"):
+			assert.Contains(t, verifiedErrors, "\"paths./foo.get.responses\" must not validate the schema (not)")
+			assert.Contains(t, verifiedErrors, "paths./foo.get.responses in body should have at least 1 properties")
+		case strings.Contains(path, "no-responses.json"):
+			assert.Contains(t, verifiedErrors, "paths./foo.get.responses in body is required")
+		default:
+			t.Logf("Returned error messages: %v", verifiedErrors)
+			t.Fatal("fixture not tested. Please add assertions for messages")
 		}
+
+		debugTest(t, path, res)
 	}
 }
 
@@ -274,197 +216,153 @@ func TestSpec_Issue18(t *testing.T) {
 		skipNotify(t)
 		t.SkipNow()
 	}
+
 	files, _ := filepath.Glob(filepath.Join("fixtures", "bugs", "18", "*.json"))
 	for _, path := range files {
 		t.Logf("Tested spec=%s", path)
-		doc, err := loads.Spec(path)
-		if assert.NoError(t, err) {
-			validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-			validator.SetContinueOnErrors(true)
-			res, _ := validator.Validate(doc)
-			assert.False(t, res.IsValid())
+		res, _ := loadAndValidate(t, path)
+		assert.False(t, res.IsValid())
 
-			var verifiedErrors []string
-			for _, e := range res.Errors {
-				verifiedErrors = append(verifiedErrors, e.Error())
-			}
-			switch {
-			case strings.Contains(path, "headerItems.json"):
-				assert.Contains(t, verifiedErrors, "X-Foo in header has invalid pattern: \")<-- bad pattern\"")
-			case strings.Contains(path, "headers.json"):
-				assert.Contains(t, verifiedErrors, "in operation \"\", header X-Foo for default response has invalid pattern \")<-- bad pattern\": error parsing regexp: unexpected ): `)<-- bad pattern`")
-				//  in operation \"\", header X-Foo for default response has invalid pattern \")<-- bad pattern\": error parsing regexp: unexpected ): `)<-- bad pattern`
-				assert.Contains(t, verifiedErrors, "in operation \"\", header X-Foo for response 402 has invalid pattern \")<-- bad pattern\": error parsing regexp: unexpected ): `)<-- bad pattern`")
-				//  in operation "", header X-Foo for response 402 has invalid pattern ")<-- bad pattern": error parsing regexp: unexpected ): `)<-- bad pattern`
+		verifiedErrors := verifiedTestErrors(res)
+		switch {
+		case strings.Contains(path, "headerItems.json"):
+			assert.Contains(t, verifiedErrors, "X-Foo in header has invalid pattern: \")<-- bad pattern\"")
+		case strings.Contains(path, "headers.json"):
+			assert.Contains(t, verifiedErrors, "in operation \"\", header X-Foo for default response has invalid pattern \")<-- bad pattern\": error parsing regexp: unexpected ): `)<-- bad pattern`")
+			//  in operation \"\", header X-Foo for default response has invalid pattern \")<-- bad pattern\": error parsing regexp: unexpected ): `)<-- bad pattern`
+			assert.Contains(t, verifiedErrors, "in operation \"\", header X-Foo for response 402 has invalid pattern \")<-- bad pattern\": error parsing regexp: unexpected ): `)<-- bad pattern`")
+			//  in operation "", header X-Foo for response 402 has invalid pattern ")<-- bad pattern": error parsing regexp: unexpected ): `)<-- bad pattern`
 
-			case strings.Contains(path, "paramItems.json"):
-				assert.Contains(t, verifiedErrors, "body param \"user\" for \"\" has invalid items pattern: \")<-- bad pattern\"")
-				// Updated message: from "user.items in body has invalid pattern: \")<-- bad pattern\"" to:
-				assert.Contains(t, verifiedErrors, "default value for user in body does not validate its schema")
-				assert.Contains(t, verifiedErrors, "user.items.default in body has invalid pattern: \")<-- bad pattern\"")
-			case strings.Contains(path, "parameters.json"):
-				assert.Contains(t, verifiedErrors, "operation \"\" has invalid pattern in param \"userId\": \")<-- bad pattern\"")
-			case strings.Contains(path, "schema.json"):
-				// TODO: strange that the text does not say response "200"...
-				assert.Contains(t, verifiedErrors, "200 in response has invalid pattern: \")<-- bad pattern\"")
-			default:
-				t.Logf("Returned error messages: %v", verifiedErrors)
-				t.Fatal("fixture not tested. Please add assertions for messages")
-			}
-
-			if DebugTest && t.Failed() {
-				if len(verifiedErrors) > 0 {
-					t.Logf("DEVMODE: Returned error messages validating %s ", path)
-					for _, v := range verifiedErrors {
-						t.Logf("%s", v)
-					}
-				}
-			}
+		case strings.Contains(path, "paramItems.json"):
+			assert.Contains(t, verifiedErrors, "body param \"user\" for \"\" has invalid items pattern: \")<-- bad pattern\"")
+			// Updated message: from "user.items in body has invalid pattern: \")<-- bad pattern\"" to:
+			assert.Contains(t, verifiedErrors, "default value for user in body does not validate its schema")
+			assert.Contains(t, verifiedErrors, "user.items.default in body has invalid pattern: \")<-- bad pattern\"")
+		case strings.Contains(path, "parameters.json"):
+			assert.Contains(t, verifiedErrors, "operation \"\" has invalid pattern in param \"userId\": \")<-- bad pattern\"")
+		case strings.Contains(path, "schema.json"):
+			// TODO: strange that the text does not say response "200"...
+			assert.Contains(t, verifiedErrors, "200 in response has invalid pattern: \")<-- bad pattern\"")
+		default:
+			t.Logf("Returned error messages: %v", verifiedErrors)
+			t.Fatal("fixture not tested. Please add assertions for messages")
 		}
+
+		debugTest(t, path, res)
 	}
 }
 
 // check if a fragment path parameter is recognized, without error
 func TestSpec_Issue39(t *testing.T) {
-	path := "swagger.yml"
-	fp := filepath.Join("fixtures", "bugs", "39", path)
-
-	// as swagger spec
-	doc, err := loads.Spec(fp)
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.True(t, res.IsValid())
-
-		var verifiedErrors []string
-		for _, e := range res.Errors {
-			verifiedErrors = append(verifiedErrors, e.Error())
-		}
-		switch {
-		case strings.Contains(path, "swagger.yml"):
-			assert.Empty(t, verifiedErrors)
-		default:
-			t.Logf("Returned error messages: %v", verifiedErrors)
-			t.Fatal("fixture not tested. Please add assertions for messages")
-		}
-		if DebugTest && t.Failed() {
-			if len(verifiedErrors) > 0 {
-				t.Logf("DEVMODE: Returned error messages validating %s ", path)
-				for _, v := range verifiedErrors {
-					t.Logf("%s", v)
-				}
-			}
-		}
-	}
+	fp := filepath.Join("fixtures", "bugs", "39", "swagger.yml")
+	res, _ := loadAndValidate(t, fp)
+	assert.True(t, res.IsValid())
+	assert.Empty(t, res.Errors)
+	debugTest(t, fp, res)
 }
 
 func TestSpec_ValidateDuplicatePropertyNames(t *testing.T) {
 	// simple allOf
 	doc, err := loads.Spec(filepath.Join("fixtures", "validation", "duplicateprops.json"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
-		validator.spec = doc
-		res := validator.validateDuplicatePropertyNames()
-		assert.NotEmpty(t, res.Errors)
-		assert.Len(t, res.Errors, 1)
+	require.NoError(t, err)
 
-	}
+	validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
+	validator.spec = doc
+	res := validator.validateDuplicatePropertyNames()
+	assert.NotEmpty(t, res.Errors)
+	assert.Len(t, res.Errors, 1)
 
 	// nested allOf
 	doc, err = loads.Spec(filepath.Join("fixtures", "validation", "nestedduplicateprops.json"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
-		validator.spec = doc
-		res := validator.validateDuplicatePropertyNames()
-		assert.NotEmpty(t, res.Errors)
-		assert.Len(t, res.Errors, 1)
+	require.NoError(t, err)
 
-	}
+	validator = NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
+	validator.spec = doc
+	res = validator.validateDuplicatePropertyNames()
+	assert.NotEmpty(t, res.Errors)
+	assert.Len(t, res.Errors, 1)
 }
 
 func TestSpec_ValidateNonEmptyPathParameterNames(t *testing.T) {
 	doc, err := loads.Spec(filepath.Join("fixtures", "validation", "empty-path-param-name.json"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
-		validator.spec = doc
-		res := validator.validateNonEmptyPathParamNames()
-		assert.NotEmpty(t, res.Errors)
-		assert.Len(t, res.Errors, 1)
+	require.NoError(t, err)
 
-	}
+	validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
+	validator.spec = doc
+	res := validator.validateNonEmptyPathParamNames()
+	assert.NotEmpty(t, res.Errors)
+	assert.Len(t, res.Errors, 1)
 }
 
 func TestSpec_ValidateCircularAncestry(t *testing.T) {
 	doc, err := loads.Spec(filepath.Join("fixtures", "validation", "direct-circular-ancestor.json"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
-		validator.spec = doc
-		res := validator.validateDuplicatePropertyNames()
-		assert.NotEmpty(t, res.Errors)
-		assert.Len(t, res.Errors, 1)
-	}
+	require.NoError(t, err)
+
+	validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
+	validator.spec = doc
+	res := validator.validateDuplicatePropertyNames()
+	assert.NotEmpty(t, res.Errors)
+	assert.Len(t, res.Errors, 1)
 
 	doc, err = loads.Spec(filepath.Join("fixtures", "validation", "indirect-circular-ancestor.json"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
-		validator.spec = doc
-		res := validator.validateDuplicatePropertyNames()
-		assert.NotEmpty(t, res.Errors)
-		assert.Len(t, res.Errors, 1)
-	}
+	require.NoError(t, err)
+
+	validator = NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
+	validator.spec = doc
+	res = validator.validateDuplicatePropertyNames()
+	assert.NotEmpty(t, res.Errors)
+	assert.Len(t, res.Errors, 1)
 
 	doc, err = loads.Spec(filepath.Join("fixtures", "validation", "recursive-circular-ancestor.json"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
-		validator.spec = doc
-		res := validator.validateDuplicatePropertyNames()
-		assert.NotEmpty(t, res.Errors)
-		assert.Len(t, res.Errors, 1)
-	}
+	require.NoError(t, err)
 
+	validator = NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
+	validator.spec = doc
+	res = validator.validateDuplicatePropertyNames()
+	assert.NotEmpty(t, res.Errors)
+	assert.Len(t, res.Errors, 1)
 }
 
 func TestSpec_ValidateReferenced(t *testing.T) {
 	doc, err := loads.Spec(filepath.Join("fixtures", "validation", "valid-referenced.yml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
-		validator.spec = doc
-		validator.analyzer = analysis.New(doc.Spec())
-		res := validator.validateReferenced()
-		assert.Empty(t, res.Errors)
-	}
+	require.NoError(t, err)
+
+	validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
+	validator.spec = doc
+	validator.analyzer = analysis.New(doc.Spec())
+	res := validator.validateReferenced()
+	assert.Empty(t, res.Errors)
 
 	doc, err = loads.Spec(filepath.Join("fixtures", "validation", "invalid-referenced.yml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
-		validator.spec = doc
-		validator.analyzer = analysis.New(doc.Spec())
-		res := validator.validateReferenced()
-		assert.Empty(t, res.Errors)
-		assert.NotEmpty(t, res.Warnings)
-		assert.Len(t, res.Warnings, 3)
-	}
+	require.NoError(t, err)
+
+	validator = NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
+	validator.spec = doc
+	validator.analyzer = analysis.New(doc.Spec())
+	res = validator.validateReferenced()
+	assert.Empty(t, res.Errors)
+	assert.NotEmpty(t, res.Warnings)
+	assert.Len(t, res.Warnings, 3)
 }
 
 func TestSpec_ValidateReferencesValid(t *testing.T) {
 	doc, err := loads.Spec(filepath.Join("fixtures", "validation", "valid-ref.json"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
-		validator.spec = doc
-		validator.analyzer = analysis.New(doc.Spec())
-		res := validator.validateReferencesValid()
-		assert.Empty(t, res.Errors)
-	}
+	require.NoError(t, err)
+
+	validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
+	validator.spec = doc
+	validator.analyzer = analysis.New(doc.Spec())
+	res := validator.validateReferencesValid()
+	assert.Empty(t, res.Errors)
 
 	doc, err = loads.Spec(filepath.Join("fixtures", "validation", "invalid-ref.json"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
-		validator.spec = doc
-		validator.analyzer = analysis.New(doc.Spec())
-		res := validator.validateReferencesValid()
-		assert.NotEmpty(t, res.Errors)
-		assert.Len(t, res.Errors, 1)
-	}
+	require.NoError(t, err)
+
+	validator = NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
+	validator.spec = doc
+	validator.analyzer = analysis.New(doc.Spec())
+	res = validator.validateReferencesValid()
+	assert.NotEmpty(t, res.Errors)
 }
 
 func TestSpec_ValidateRequiredDefinitions(t *testing.T) {
@@ -518,7 +416,7 @@ func TestSpec_ValidateParameters(t *testing.T) {
 	assert.Empty(t, res.Errors)
 
 	sw := doc.Spec()
-	sw.Paths.Paths["/pets"].Get.Parameters = append(sw.Paths.Paths["/pets"].Get.Parameters, *spec.QueryParam("limit").Typed("string", ""))
+	sw.Paths.Paths["/pets"].Get.Parameters = append(sw.Paths.Paths["/pets"].Get.Parameters, *spec.QueryParam("limit").Typed(stringType, ""))
 	res = validator.validateParameters()
 	assert.NotEmpty(t, res.Errors)
 
@@ -583,29 +481,29 @@ func TestSpec_ValidateItems(t *testing.T) {
 
 	// in operation parameters
 	sw := doc.Spec()
-	sw.Paths.Paths["/pets"].Get.Parameters[0].Type = "array"
+	sw.Paths.Paths["/pets"].Get.Parameters[0].Type = arrayType
 	res = validator.validateItems()
 	assert.NotEmpty(t, res.Errors)
 
-	sw.Paths.Paths["/pets"].Get.Parameters[0].Items = spec.NewItems().Typed("string", "")
+	sw.Paths.Paths["/pets"].Get.Parameters[0].Items = spec.NewItems().Typed(stringType, "")
 	res = validator.validateItems()
 	assert.Empty(t, res.Errors)
 
-	sw.Paths.Paths["/pets"].Get.Parameters[0].Items = spec.NewItems().Typed("array", "")
+	sw.Paths.Paths["/pets"].Get.Parameters[0].Items = spec.NewItems().Typed(arrayType, "")
 	res = validator.validateItems()
 	assert.NotEmpty(t, res.Errors)
 
-	sw.Paths.Paths["/pets"].Get.Parameters[0].Items.Items = spec.NewItems().Typed("string", "")
+	sw.Paths.Paths["/pets"].Get.Parameters[0].Items.Items = spec.NewItems().Typed(stringType, "")
 	res = validator.validateItems()
 	assert.Empty(t, res.Errors)
 
 	// in global parameters
 	sw.Parameters = make(map[string]spec.Parameter)
-	sw.Parameters["other"] = *spec.SimpleArrayParam("other", "array", "csv")
+	sw.Parameters["other"] = *spec.SimpleArrayParam("other", arrayType, "csv")
 	res = validator.validateItems()
 	assert.Empty(t, res.Errors)
 
-	//pp := spec.SimpleArrayParam("other", "array", "")
+	//pp := spec.SimpleArrayParam("other", arrayType, "")
 	//pp.Items = nil
 	//sw.Parameters["other"] = *pp
 	//res = validator.validateItems()
@@ -619,13 +517,13 @@ func TestSpec_ValidateItems(t *testing.T) {
 	sw = doc.Spec()
 
 	pa := sw.Paths.Paths["/pets"]
-	pa.Parameters = []spec.Parameter{*spec.SimpleArrayParam("another", "array", "csv")}
+	pa.Parameters = []spec.Parameter{*spec.SimpleArrayParam("another", arrayType, "csv")}
 	sw.Paths.Paths["/pets"] = pa
 	res = validator.validateItems()
 	assert.Empty(t, res.Errors)
 
 	pa = sw.Paths.Paths["/pets"]
-	pp := spec.SimpleArrayParam("other", "array", "")
+	pp := spec.SimpleArrayParam("other", arrayType, "")
 	pp.Items = nil
 	pa.Parameters = []spec.Parameter{*pp}
 	sw.Paths.Paths["/pets"] = pa
@@ -652,7 +550,7 @@ func TestSpec_ValidateItems(t *testing.T) {
 	pa = sw.Paths.Paths["/pets"]
 	rp := pa.Post.Responses.StatusCodeResponses[200]
 	var hdr spec.Header
-	hdr.Type = "array"
+	hdr.Type = arrayType
 	rp.Headers = make(map[string]spec.Header)
 	rp.Headers["X-YADA"] = hdr
 	pa.Post.Responses.StatusCodeResponses[200] = rp
@@ -677,141 +575,125 @@ func TestSpec_ValidateItems(t *testing.T) {
 func TestSpec_ValidDoc(t *testing.T) {
 	fp := filepath.Join("fixtures", "local_expansion", "spec.yaml")
 	doc2, err := loads.Spec(fp)
-	if assert.NoError(t, err) {
-		err := Spec(doc2, strfmt.Default)
-		assert.NoError(t, err)
-	}
+	require.NoError(t, err)
+	err = Spec(doc2, strfmt.Default)
+	assert.NoError(t, err)
 }
 
 // Check higher level behavior on invalid spec doc
 func TestSpec_InvalidDoc(t *testing.T) {
 	doc, err := loads.Spec(filepath.Join("fixtures", "validation", "default", "invalid-default-value-parameter.json"))
-	if assert.NoError(t, err) {
-		err := Spec(doc, strfmt.Default)
-		assert.Error(t, err)
-	}
+	require.NoError(t, err)
+	err = Spec(doc, strfmt.Default)
+	assert.Error(t, err)
 }
 
 func TestSpec_Validate_InvalidInterface(t *testing.T) {
 	fp := filepath.Join("fixtures", "local_expansion", "spec.yaml")
 	doc2, err := loads.Spec(fp)
-	if assert.NoError(t, err) {
-		if assert.NotNil(t, doc2) {
-			validator := NewSpecValidator(doc2.Schema(), strfmt.Default)
-			bug := "bzzz"
-			res, _ := validator.Validate(bug)
-			assert.NotEmpty(t, res.Errors)
-			assert.Contains(t, res.Errors[0].Error(), "can only validate spec.Document objects")
-		}
-	}
+	require.NoError(t, err)
+	require.NotNil(t, doc2)
+
+	validator := NewSpecValidator(doc2.Schema(), strfmt.Default)
+	bug := "bzzz"
+	res, _ := validator.Validate(bug)
+	assert.NotEmpty(t, res.Errors)
+	assert.Contains(t, res.Errors[0].Error(), "can only validate spec.Document objects")
 }
 
 func TestSpec_ValidateBodyFormDataParams(t *testing.T) {
-	doc, err := loads.Spec(filepath.Join("fixtures", "validation", "invalid-formdata-body-params.json"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.NotEmpty(t, res.Errors)
-		assert.Len(t, res.Errors, 1)
-	}
+	res, _ := loadAndValidate(t, filepath.Join("fixtures", "validation", "invalid-formdata-body-params.json"))
+	assert.NotEmpty(t, res.Errors)
+	assert.Len(t, res.Errors, 1)
 }
 
 func TestSpec_Issue73(t *testing.T) {
-	doc, err := loads.Spec(filepath.Join("fixtures", "bugs", "73", "fixture-swagger.yaml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.Empty(t, res.Errors, " in fixture-swagger.yaml")
-	}
+	res, _ := loadAndValidate(t, filepath.Join("fixtures", "bugs", "73", "fixture-swagger.yaml"))
+	assert.Empty(t, res.Errors, " in fixture-swagger.yaml")
 
-	doc, err = loads.Spec(filepath.Join("fixtures", "bugs", "73", "fixture-swagger-2.yaml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.Empty(t, res.Errors, "in fixture-swagger-2.yaml")
-	}
+	res, _ = loadAndValidate(t, filepath.Join("fixtures", "bugs", "73", "fixture-swagger-2.yaml"))
+	assert.Empty(t, res.Errors, "in fixture-swagger-2.yaml")
 
-	doc, err = loads.Spec(filepath.Join("fixtures", "bugs", "73", "fixture-swagger-3.yaml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.Empty(t, res.Errors, "in fixture-swagger-3.yaml")
-	}
+	res, _ = loadAndValidate(t, filepath.Join("fixtures", "bugs", "73", "fixture-swagger-3.yaml"))
+	assert.Empty(t, res.Errors, "in fixture-swagger-3.yaml")
 
-	doc, err = loads.Spec(filepath.Join("fixtures", "bugs", "73", "fixture-swagger-good.yaml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.Empty(t, res.Errors, " in fixture-swagger-good.yaml")
-	}
+	res, _ = loadAndValidate(t, filepath.Join("fixtures", "bugs", "73", "fixture-swagger-good.yaml"))
+	assert.Empty(t, res.Errors, " in fixture-swagger-good.yaml")
 }
 
 func TestSpec_Issue1341(t *testing.T) {
 	// testing recursive walk with defaults and examples
-	doc, err := loads.Spec(filepath.Join("fixtures", "bugs", "1341", "fixture-1341-good.yaml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.Empty(t, res.Errors, " in fixture-1341-good.yaml")
-		assert.Len(t, res.Warnings, 1, " in fixture-1341-good.yaml")
-	}
+	res, _ := loadAndValidate(t, filepath.Join("fixtures", "bugs", "1341", "fixture-1341-good.yaml"))
+	assert.Empty(t, res.Errors, " in fixture-1341-good.yaml")
+	assert.Len(t, res.Warnings, 1, " in fixture-1341-good.yaml")
 
-	doc, err = loads.Spec(filepath.Join("fixtures", "bugs", "1341", "fixture-1341.yaml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.Empty(t, res.Errors, "in fixture-1341.yaml")
-		assert.Empty(t, res.Warnings, "in fixture-1341.yaml")
-	}
+	res, _ = loadAndValidate(t, filepath.Join("fixtures", "bugs", "1341", "fixture-1341.yaml"))
+	assert.Empty(t, res.Errors, "in fixture-1341.yaml")
+	assert.Empty(t, res.Warnings, "in fixture-1341.yaml")
 
-	doc, err = loads.Spec(filepath.Join("fixtures", "bugs", "1341", "fixture-1341-2.yaml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.Empty(t, res.Errors, "in fixture-1341-2.yaml")
-		assert.Empty(t, res.Warnings, "in fixture-1341-2.yaml")
-	}
+	res, _ = loadAndValidate(t, filepath.Join("fixtures", "bugs", "1341", "fixture-1341-2.yaml"))
+	assert.Empty(t, res.Errors, "in fixture-1341-2.yaml")
+	assert.Empty(t, res.Warnings, "in fixture-1341-2.yaml")
 
-	doc, err = loads.Spec(filepath.Join("fixtures", "bugs", "1341", "fixture-1341-3.yaml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.Empty(t, res.Errors, "in fixture-1341-3.yaml")
-		assert.Len(t, res.Warnings, 4, "in fixture-1341-3.yaml")
-	}
+	res, _ = loadAndValidate(t, filepath.Join("fixtures", "bugs", "1341", "fixture-1341-3.yaml"))
+	assert.Empty(t, res.Errors, "in fixture-1341-3.yaml")
+	assert.Len(t, res.Warnings, 4, "in fixture-1341-3.yaml")
 
-	doc, err = loads.Spec(filepath.Join("fixtures", "bugs", "1341", "fixture-1341-4.yaml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.Empty(t, res.Errors, "in fixture-1341-4.yaml")
-		assert.Empty(t, res.Warnings, "in fixture-1341-4.yaml")
-	}
+	res, _ = loadAndValidate(t, filepath.Join("fixtures", "bugs", "1341", "fixture-1341-4.yaml"))
+	assert.Empty(t, res.Errors, "in fixture-1341-4.yaml")
+	assert.Empty(t, res.Warnings, "in fixture-1341-4.yaml")
 
-	doc, err = loads.Spec(filepath.Join("fixtures", "bugs", "1341", "fixture-1341-5.yaml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		res, _ := validator.Validate(doc)
-		assert.Len(t, res.Errors, 4, "in fixture-1341-5.yaml")
-		assert.Empty(t, res.Warnings, "in fixture-1341-5.yaml")
-	}
+	res, _ = loadAndValidate(t, filepath.Join("fixtures", "bugs", "1341", "fixture-1341-5.yaml"))
+	assert.Len(t, res.Errors, 4, "in fixture-1341-5.yaml")
+	assert.Empty(t, res.Warnings, "in fixture-1341-5.yaml")
+}
+
+// test go-swagger/go-swagger#1614 (circular refs)
+func Test_Issue1614(t *testing.T) {
+	path := filepath.Join("fixtures", "bugs", "1614", "gitea.json")
+	testIssue(t, path, 0, 3)
+}
+
+// Test go-swagger/go-swagger#1621 (remote $ref)
+func Test_Issue1621(t *testing.T) {
+	path := filepath.Join("fixtures", "bugs", "1621", "fixture-1621.yaml")
+	testIssue(t, path, 0, 0)
+}
+
+// Test go-swagger/go-swagger#1429 (remote $ref)
+func Test_Issue1429(t *testing.T) {
+	path := filepath.Join("fixtures", "bugs", "1429", "swagger.yaml")
+	testIssue(t, path, 0, 0)
 }
 
 func TestSpec_ValidationTypeMismatch(t *testing.T) {
 	doc, err := loads.Spec(filepath.Join("fixtures", "validation", "type-keyword-mismatch.yaml"))
-	if assert.NoError(t, err) {
-		validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-		validator.spec = doc
-		validator.analyzer = analysis.New(doc.Spec())
-		res := validator.validateParameters()
-		var warnings []string
-		for _, w := range res.Warnings {
-			warnings = append(warnings, w.Error())
+	require.NoError(t, err)
+	validator := NewSpecValidator(doc.Schema(), strfmt.Default)
+	validator.spec = doc
+	validator.analyzer = analysis.New(doc.Spec())
+	res := validator.validateParameters()
+	assert.NotEmpty(t, res.Warnings)
+	assert.Len(t, res.Warnings, 3)
+
+	warnings := verifiedTestWarnings(res)
+	assert.Contains(t, warnings, `validation keywords of parameter "id" in path "/test/{id}/string" don't match its type string`)
+	assert.Contains(t, warnings, `validation keywords of parameter "id" in path "/test/{id}/integer" don't match its type integer`)
+	assert.Contains(t, warnings, `validation keywords of parameter "id" in path "/test/{id}/array" don't match its type array`)
+}
+
+func loadAndValidate(t *testing.T, fp string, early ...bool) (*Result, *Result) {
+	doc, err := loads.Spec(fp)
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	validator := NewSpecValidator(doc.Schema(), strfmt.Default)
+	// for testing, we enable "ContinueOnErrors" by default
+	if len(early) == 0 {
+		validator.Options = Opts{ContinueOnErrors: true}
+	} else {
+		for _, flag := range early {
+			validator.Options = Opts{ContinueOnErrors: flag}
 		}
-		assert.NotEmpty(t, res.Warnings)
-		assert.Len(t, res.Warnings, 3)
-		assert.Contains(t, warnings, `validation keywords of parameter "id" in path "/test/{id}/string" don't match its type string`)
-		assert.Contains(t, warnings, `validation keywords of parameter "id" in path "/test/{id}/integer" don't match its type integer`)
-		assert.Contains(t, warnings, `validation keywords of parameter "id" in path "/test/{id}/array" don't match its type array`)
 	}
+	return validator.Validate(doc)
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -697,3 +697,36 @@ func loadAndValidate(t *testing.T, fp string, early ...bool) (*Result, *Result) 
 	}
 	return validator.Validate(doc)
 }
+
+func TestItemsProperty_Issue43(t *testing.T) {
+	for _, fixture := range []string{
+		"fixture-43.yaml",
+		"fixture-43-variants.yaml",
+		"fixture-1456.yaml",
+	} {
+		fp := filepath.Join("fixtures", "bugs", "43", fixture)
+		res, warnings := loadAndValidate(t, fp)
+		assert.Truef(t, res.IsValid(), "expected spec from %s to be valid", fixture)
+		assert.Emptyf(t, res.Errors, "expected no error in %s", fixture)
+		assert.Emptyf(t, res.Warnings, "expected no warning in %s", fixture)
+		assert.Emptyf(t, warnings, "expected no warning in %s", fixture)
+	}
+
+	fp := filepath.Join("fixtures", "bugs", "43", "fixture-43-fail.yaml")
+	res, _ := loadAndValidate(t, fp)
+	assert.Falsef(t, res.IsValid(), "expected spec to be invalid")
+	assert.True(t, len(res.Errors) > 3)
+
+	fp = filepath.Join("fixtures", "validation", "fixture-1171.yaml")
+	res, _ = loadAndValidate(t, fp)
+	assert.Falsef(t, res.IsValid(), "expected spec to be invalid")
+	assert.True(t, len(res.Errors) > 3)
+	found := false
+	for _, e := range res.Errors {
+		found = strings.Contains(e.Error(), "array requires items definition")
+		if found {
+			break
+		}
+	}
+	assert.True(t, found)
+}

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -115,83 +115,67 @@ func Test_GoSwaggerTestCases(t *testing.T) {
 		"fixtures/go-swagger/specs/resolution.json":                      true,
 	}
 
-	if testGoSwaggerSpecs(t, "./fixtures/go-swagger", expectedFailures, expectedLoadFailures, true) != 0 {
-		t.Fail()
-	}
+	testGoSwaggerSpecs(t, filepath.Join(".", "fixtures", "go-swagger"), expectedFailures, expectedLoadFailures, true)
 }
 
-// A non regression test re "swagger validate" expectations
+func wantSwaggerTest(info os.FileInfo) bool {
+	f := info.Name()
+	return !info.IsDir() && (strings.HasSuffix(f, ".yaml") || strings.HasSuffix(f, ".yml") || strings.HasSuffix(f, ".json"))
+}
+
+// A non regression test re "swagger validate" expectations.
 // Just validates all fixtures in ./fixtures/go-swagger (excluded codegen cases)
-func testGoSwaggerSpecs(t *testing.T, path string, expectToFail, expectToFailOnLoad map[string]bool, haltOnErrors bool) (errs int) {
-	// countSpec := 0
+func testGoSwaggerSpecs(t *testing.T, path string, expectToFail, expectToFailOnLoad map[string]bool, haltOnErrors bool) {
 	err := filepath.Walk(path,
 		func(path string, info os.FileInfo, err error) error {
 			t.Run(path, func(t *testing.T) {
 				t.Parallel()
-				shouldNotLoad := false
-				shouldFail := false
-				if _, ok := expectToFailOnLoad[path]; ok {
-					shouldNotLoad = expectToFailOnLoad[path]
-				}
-				if _, ok := expectToFail[path]; ok {
-					shouldFail = expectToFail[path]
-				}
-				if !info.IsDir() && (strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml") || strings.HasSuffix(info.Name(), ".json")) {
-					if DebugTest {
-						t.Logf("Testing validation status for spec: %s", path)
-					}
-					doc, err := loads.Spec(path)
-					if shouldNotLoad {
-						if !assert.Errorf(t, err, "Expected this spec not to load: %s", path) {
-							errs++
-						}
-					} else {
-						if !assert.NoErrorf(t, err, "Expected this spec to load without error: %s", path) {
-							errs++
-						}
-					}
-					if errs > 0 {
-						if haltOnErrors {
-							assert.FailNow(t, "Test Halted: stop on error mode")
-							return
-						}
-					}
-					if shouldNotLoad {
-						return
-					}
 
-					// Validate the spec document
-					validator := NewSpecValidator(doc.Schema(), strfmt.Default)
-					validator.SetContinueOnErrors(true)
-					res, _ := validator.Validate(doc)
-					if shouldFail {
-						if !assert.Falsef(t, res.IsValid(), "Expected this spec to be invalid: %s", path) {
-							errs++
-						}
-					} else {
-						if !assert.Truef(t, res.IsValid(), "Expected this spec to be valid: %s", path) {
-							t.Logf("Errors reported by validation on %s", path)
-							for _, e := range res.Errors {
-								t.Log(e)
-							}
-							errs++
-						}
-
-					}
+				npath := filepath.ToSlash(path)
+				shouldNotLoad := expectToFailOnLoad[npath]
+				shouldFail := expectToFail[npath]
+				if !wantSwaggerTest(info) {
+					return
 				}
-				if haltOnErrors && errs > 0 {
+				if DebugTest {
+					t.Logf("Testing validation status for spec: %s", path)
+				}
+
+				doc, err := loads.Spec(path)
+				if shouldNotLoad {
+					assert.Errorf(t, err, "expected this spec not to load: %s", path)
+					return
+				}
+				assert.NoErrorf(t, err, "expected this spec to load without error: %s", path)
+
+				if haltOnErrors && t.Failed() {
+					assert.FailNow(t, "test Halted: stop on error mode")
+					return
+				}
+
+				// Validate the spec document
+				validator := NewSpecValidator(doc.Schema(), strfmt.Default)
+				validator.SetContinueOnErrors(true)
+				res, _ := validator.Validate(doc)
+				if shouldFail {
+					assert.Falsef(t, res.IsValid(), "expected this spec to be invalid: %s", path)
+				} else {
+					assert.Truef(t, res.IsValid(), "expected this spec to be valid: %s", path)
+				}
+				t.Logf("Errors reported by validation on %s", path)
+				for _, e := range res.Errors {
+					t.Log(e)
+				}
+
+				if haltOnErrors && t.Failed() {
 					assert.FailNow(t, "Test halted: stop on error mode")
 					return
 				}
 			})
 			return nil
 		})
-	if err != nil {
-		t.Logf("%v", err)
-		errs++
-	}
+	assert.NoErrorf(t, err, "walk: %v", err)
 	if t.Failed() {
 		log.Printf("A change in expected validation status has been detected")
 	}
-	return
 }

--- a/type_test.go
+++ b/type_test.go
@@ -34,17 +34,17 @@ func TestType_schemaInfoForType(t *testing.T) {
 	testTypes := []expectedJSONType{
 		{
 			value:                 []byte("abc"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "byte",
 		},
 		{
 			value:                 strfmt.Date(time.Date(2014, 10, 10, 0, 0, 0, 0, time.UTC)),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "date",
 		},
 		{
 			value:                 strfmt.NewDateTime(),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "date-time",
 		},
 		{
@@ -55,92 +55,92 @@ func TestType_schemaInfoForType(t *testing.T) {
 		},
 		{
 			value:                 strfmt.URI("http://thisisleadingusnowhere.com"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "uri",
 		},
 		{
 			value:                 strfmt.Email("fred@esasymoney.com"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "email",
 		},
 		{
 			value:                 strfmt.Hostname("www.github.com"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "hostname",
 		},
 		{
 			value:                 strfmt.Password("secret"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "password",
 		},
 		{
 			value:                 strfmt.IPv4("192.168.224.1"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "ipv4",
 		},
 		{
 			value:                 strfmt.IPv6("::1"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "ipv6",
 		},
 		{
 			value:                 strfmt.MAC("01:02:03:04:05:06"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "mac",
 		},
 		{
 			value:                 strfmt.UUID("a8098c1a-f86e-11da-bd1a-00112444be1e"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "uuid",
 		},
 		{
 			value:                 strfmt.UUID3("bcd02e22-68f0-3046-a512-327cca9def8f"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "uuid3",
 		},
 		{
 			value:                 strfmt.UUID4("025b0d74-00a2-4048-bf57-227c5111bb34"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "uuid4",
 		},
 		{
 			value:                 strfmt.UUID5("886313e1-3b8a-5372-9b90-0c9aee199e5d"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "uuid5",
 		},
 		{
 			value:                 strfmt.ISBN("0321751043"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "isbn",
 		},
 		{
 			value:                 strfmt.ISBN10("0321751043"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "isbn10",
 		},
 		{
 			value:                 strfmt.ISBN13("978-0321751041"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "isbn13",
 		},
 		{
 			value:                 strfmt.CreditCard("4111-1111-1111-1111"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "creditcard",
 		},
 		{
 			value:                 strfmt.SSN("111-11-1111"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "ssn",
 		},
 		{
 			value:                 strfmt.HexColor("#FFFFFF"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "hexcolor",
 		},
 		{
 			value:                 strfmt.RGBColor("rgb(255,255,255)"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "rgbcolor",
 		},
 		// Numerical values
@@ -232,7 +232,7 @@ func TestType_schemaInfoForType(t *testing.T) {
 		},
 		{
 			value:                 "simply a string",
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "",
 		},
 		{
@@ -243,17 +243,17 @@ func TestType_schemaInfoForType(t *testing.T) {
 		},
 		{
 			value:                 strfmt.Base64("ZWxpemFiZXRocG9zZXk="),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "byte",
 		},
 		{
 			value:                 strfmt.Duration(0),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "duration",
 		},
 		{
 			value:                 strfmt.NewObjectId("507f1f77bcf86cd799439011"),
-			expectedJSONType:      "string",
+			expectedJSONType:      stringType,
 			expectedSwaggerFormat: "bsonobjectid",
 		},
 		/*
@@ -276,8 +276,7 @@ func TestType_schemaInfoForType(t *testing.T) {
 
 	// Check file declarations as io.ReadCloser are properly detected
 	myFile := runtime.File{}
-	var myReader io.ReadCloser
-	myReader = &myFile
+	var myReader io.ReadCloser = &myFile
 	jsonType, swaggerFormat := v.schemaInfoForType(myReader)
 	assert.Equal(t, "file", jsonType)
 	assert.Equal(t, "", swaggerFormat)

--- a/validator_test.go
+++ b/validator_test.go
@@ -25,8 +25,8 @@ import (
 
 func TestNumberValidator_EdgeCases(t *testing.T) {
 	// Apply
-	var min float64 = float64(math.MinInt32 - 1)
-	var max float64 = float64(math.MaxInt32 + 1)
+	var min = float64(math.MinInt32 - 1)
+	var max = float64(math.MaxInt32 + 1)
 
 	v := numberValidator{
 		Path: "path",
@@ -58,9 +58,7 @@ func TestNumberValidator_EdgeCases(t *testing.T) {
 	// Now for different scenarios on Minimum, Maximum
 	// - The Maximum value does not respect the Type|Format specification
 	// - Value is checked as float64 with Maximum as float64 and fails
-	res := new(Result)
-
-	res = v.Validate(int64(math.MaxInt32 + 2))
+	res := v.Validate(int64(math.MaxInt32 + 2))
 	assert.True(t, res.HasErrors())
 	// - The Minimum value does not respect the Type|Format specification
 	// - Value is checked as float64 with Maximum as float64 and fails
@@ -170,11 +168,11 @@ func testSliceApply(t *testing.T, v *basicSliceValidator, sources []interface{})
 	}
 }
 
+/* unused
 type anything struct {
 	anyProperty int
 }
 
-/* unsused
 // hasDuplicates() is currently not exercised by common spec testcases
 // (this method is not used by the validator atm)
 // Here is a unit exerciser
@@ -193,7 +191,6 @@ func TestBasicSliceValidator_HasDuplicates(t *testing.T) {
 		{anyProperty: 3},
 	}
 	assert.False(t, s.hasDuplicates(reflect.ValueOf(vi), len(vi)))
-	// how UniqueItems() is superior? Look:   err := uniqueItems("path","body", vi)
 	assert.False(t, s.hasDuplicates(reflect.ValueOf(vs), len(vs)))
 	assert.False(t, s.hasDuplicates(reflect.ValueOf(vt), len(vt)))
 


### PR DESCRIPTION
Based upon #121 -- fixes come with commit https://github.com/go-openapi/validate/pull/119/commits/194f2098f4e68457abc5c60b9c4d693ff9ff0bfc

Fixes issues related to swagger-specific rules with array schemas and items

Default behavior of the json-schema validation is the one expected by jsonschema.

The behavior expected for swagger schemas is enabled by an option to check specifically for arrays and items.

Additional testing is carried out to check for different situations: in example, in response examples, in default values.

* extra linting work, particularly on tests.
* updated deps with other go-openapi repos
* updated golanci-lint config and disable latest round of new, unused linters

* fixes #43  (property named "items", in examples)
* fixes #83  (pure jsonschema validation of array schemas without items specification)
* fixes #108 (property named "items")
* fixes #112 (property named "items")
* contributes go-swagger/go-swagger#1456

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>