### PR TITLE
Fixes validation of duplicate operationIDs when paths are resolved from $ref's

### DIFF
--- a/fixtures/bugs/2137/fixture-2137.yaml
+++ b/fixtures/bugs/2137/fixture-2137.yaml
@@ -1,0 +1,20 @@
+swagger: "2.0"
+info:
+  description: Test
+  title: Test
+  version: "0.0.1"
+basePath: /v1
+consumes:
+  - application/json
+produces:
+  - application/json
+
+paths:
+  /test/a:
+    $ref: "#/paths/~1test"
+  /test:
+    get:
+      operationId: test
+      responses:
+        200:
+          description: OK

--- a/spec.go
+++ b/spec.go
@@ -169,9 +169,17 @@ func (s *SpecValidator) validateNonEmptyPathParamNames() *Result {
 
 func (s *SpecValidator) validateDuplicateOperationIDs() *Result {
 	// OperationID, if specified, must be unique across the board
+	var analyzer *analysis.Spec
+	if s.expanded != nil {
+		// $ref are valid: we can analyze operations on an expanded spec
+		analyzer = analysis.New(s.expanded.Spec())
+	} else {
+		// fallback on possible incomplete picture because of previous errors
+		analyzer = s.analyzer
+	}
 	res := new(Result)
 	known := make(map[string]int)
-	for _, v := range s.analyzer.OperationIDs() {
+	for _, v := range analyzer.OperationIDs() {
 		if v != "" {
 			known[v]++
 		}

--- a/spec_test.go
+++ b/spec_test.go
@@ -730,3 +730,17 @@ func TestItemsProperty_Issue43(t *testing.T) {
 	}
 	assert.True(t, found)
 }
+
+func Test_Issue2137(t *testing.T) {
+	fp := filepath.Join("fixtures", "bugs", "2137", "fixture-2137.yaml")
+	res, _ := loadAndValidate(t, fp)
+	assert.Falsef(t, res.IsValid(), "expected spec to be invalid")
+	found := false
+	for _, e := range res.Errors {
+		found = strings.Contains(e.Error(), `"test" is defined 2 times`)
+		if found {
+			break
+		}
+	}
+	assert.True(t, found)
+}


### PR DESCRIPTION
Analysis of operations to be unique across the board is now performed after $ref resolution, on an expanded version of the spec.
If some $ref errors are encountered before this check, the scope is reduced to locally available operations.

* contributes go-swagger/go-swagger#2137

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>