### PR TITLE
enabled parallel testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,33 @@ jobs:
     script:
     - gotestsum -f short-verbose -- ./...
 
-  # include linting job, but only for latest go version and amd64 arch
+  # include large spec validation sample (run once)
+  - go: 1.x
+    arch: amd64
+    script:
+    - gotestsum -f short-verbose -- -timeout=30m -args -enable-go-swagger ./...
+
+  # include linting job, but only for latest go version and amd64 arch (run once)
+  - go: 1.x
+    arch: amd64
+    install:
+      go get -u github.com/go-openapi/runtime@master
+    script:
+    - gotestsum -f short-verbose -- -timeout=30m github.com/go-openapi/runtime/...
+
+  # include go-openapi/runtime non reg job (run once)
   - go: 1.x
     arch: amd64
     install:
       go get github.com/golangci/golangci-lint/cmd/golangci-lint
     script:
     - golangci-lint run --new-from-rev master
+
+  # include -race test on short tests only (run once)
+  - go: 1.x
+    arch: amd64
+    script:
+    - gotestsum -f short-verbose -- -race ./...
 
 install:
 - GO111MODULE=off go get -u gotest.tools/gotestsum
@@ -28,8 +48,4 @@ notifications:
   slack:
     secure: EmObnQuM9Mw8J9vpFaKKHqSMN4Wsr/A9+v7ewAD5cEhA0T1P4m7MbJMiJOhxUhj/X+BFh2DamW+P2lT8mybj5wg8wnkQ2BteKA8Tawi6f9PRw2NRheO8tAi8o/npLnlmet0kc93mn+oLuqHw36w4+j5mkOl2FghkfGiUVhwrhkCP7KXQN+3TU87e+/HzQumlJ3nsE+6terVxkH3PmaUTsS5ONaODZfuxFpfb7RsoEl3skHf6d+tr+1nViLxxly7558Nc33C+W1mr0qiEvMLZ+kJ/CpGWBJ6CUJM3jm6hNe2eMuIPwEK2hxZob8c7n22VPap4K6a0bBRoydoDXaba+2sD7Ym6ivDO/DVyL44VeBBLyIiIBylDGQdZH+6SoWm90Qe/i7tnY/T5Ao5igT8f3cfQY1c3EsTfqmlDfrhmACBmwSlgkdVBLTprHL63JMY24LWmh4jhxsmMRZhCL4dze8su1w6pLN/pD1pGHtKYCEVbdTmaM3PblNRFf12XB7qosmQsgUndH4Vq3bTbU0s1pKjeDhRyLvFzvR0TBbo0pDLEoF1A/i5GVFWa7yLZNUDudQERRh7qv/xBl2excIaQ1sV4DSVm7bAE9l6Kp+yeHQJW2uN6Y3X8wu9gB9nv9l5HBze7wh8KE6PyWAOLYYqZg9/sAtsv/2GcQqXcKFF1zcA=
 script:
-- gotestsum -f short-verbose -- -race ./...
 - gotestsum -f short-verbose -- -timeout=20m -coverprofile=coverage.txt -covermode=atomic -args -enable-long ./...
-- gotestsum -f short-verbose -- -timeout=30m -args -enable-go-swagger ./...
-- go get -u github.com/go-openapi/runtime@master
-- gotestsum -f short-verbose -- -timeout=30m github.com/go-openapi/runtime/...

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ jobs:
   - go: 1.x
     arch: amd64
     install:
-      go get -u github.com/go-openapi/runtime@master
+    - GO111MODULE=off go get -u gotest.tools/gotestsum
+    - go get -u github.com/go-openapi/runtime@master
     script:
     - gotestsum -f short-verbose -- -timeout=30m github.com/go-openapi/runtime/...
 

--- a/context_test.go
+++ b/context_test.go
@@ -40,8 +40,10 @@ func TestContext_ExtractOperationType(t *testing.T) {
 		},
 	}
 
-	for idx, tc := range testCases {
+	for idx, toPin := range testCases {
+		tc := toPin
 		t.Run(fmt.Sprintf("TestCase #%d", idx), func(t *testing.T) {
+			t.Parallel()
 			op := extractOperationType(tc.Ctx)
 			assert.Equal(t, tc.ExpectedOpType, op)
 		})

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/go-openapi/analysis v0.19.16
 	github.com/go-openapi/errors v0.19.9
 	github.com/go-openapi/jsonpointer v0.19.5
-	github.com/go-openapi/loads v0.19.7
+	github.com/go-openapi/loads v0.20.0
 	github.com/go-openapi/runtime v0.19.24
-	github.com/go-openapi/spec v0.19.15
+	github.com/go-openapi/spec v0.20.0
 	github.com/go-openapi/strfmt v0.19.11
 	github.com/go-openapi/swag v0.19.12
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/go-openapi/loads v0.19.6 h1:6IAtnx22MNSjPocZZ2sV7EjgF6wW5rDC9r6ZkNxji
 github.com/go-openapi/loads v0.19.6/go.mod h1:brCsvE6j8mnbmGBh103PT/QLHfbyDxA4hsKvYBNEGVc=
 github.com/go-openapi/loads v0.19.7 h1:6cALLpCAq4tYhaic7TMbEzjv8vq/wg+0AFivNy/Bma8=
 github.com/go-openapi/loads v0.19.7/go.mod h1:brCsvE6j8mnbmGBh103PT/QLHfbyDxA4hsKvYBNEGVc=
+github.com/go-openapi/loads v0.20.0 h1:Pymw1O8zDmWeNv4kVsHd0W3cvgdp8juRa4U/U/8D/Pk=
+github.com/go-openapi/loads v0.20.0/go.mod h1:2LhKquiE513rN5xC6Aan6lYOSddlL8Mp20AW9kpviM4=
 github.com/go-openapi/runtime v0.0.0-20180920151709-4f900dc2ade9/go.mod h1:6v9a6LTXWQCdL8k1AO3cvqx5OtZY/Y9wKTgaoP6YRfA=
 github.com/go-openapi/runtime v0.19.0/go.mod h1:OwNfisksmmaZse4+gpV3Ne9AyMOlP1lt4sK4FXt0O64=
 github.com/go-openapi/runtime v0.19.4 h1:csnOgcgAiuGoM/Po7PEpKDoNulCcF3FGbSnbHfxgjMI=
@@ -91,6 +93,8 @@ github.com/go-openapi/spec v0.19.8 h1:qAdZLh1r6QF/hI/gTq+TJTvsQUodZsM7KLqkAJdiJN
 github.com/go-openapi/spec v0.19.8/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/spec v0.19.15 h1:uxh8miNJEfMm8l8ekpY7i39LcORm1xSRtoipEGl1JPk=
 github.com/go-openapi/spec v0.19.15/go.mod h1:+81FIL1JwC5P3/Iuuozq3pPE9dXdIEGxFutcFKaVbmU=
+github.com/go-openapi/spec v0.20.0 h1:HGLc8AJ7ynOxwv0Lq4TsnwLsWMawHAYiJIFzbcML86I=
+github.com/go-openapi/spec v0.20.0/go.mod h1:+81FIL1JwC5P3/Iuuozq3pPE9dXdIEGxFutcFKaVbmU=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.19.0/go.mod h1:+uW+93UVvGGq2qGaZxdDeJqSAqBqBdl+ZPMF/cC8nDY=
@@ -117,6 +121,7 @@ github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2K
 github.com/go-openapi/validate v0.19.3/go.mod h1:90Vh6jjkTn+OT1Eefm0ZixWNFjhtOH7vS9k0lo6zwJo=
 github.com/go-openapi/validate v0.19.10/go.mod h1:RKEZTUWDkxKQxN2jDT7ZnZi2bhZlbNMAuKvKB+IaGx8=
 github.com/go-openapi/validate v0.19.12/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
+github.com/go-openapi/validate v0.19.15/go.mod h1:tbn/fdOwYHgrhPBzidZfJC2MIVvs9GA7monOmWBbeCI=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -232,6 +237,8 @@ go.mongodb.org/mongo-driver v1.3.4 h1:zs/dKNwX0gYUtzwrN9lLiR15hCO0nDwQj5xXx+vjCd
 go.mongodb.org/mongo-driver v1.3.4/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
 go.mongodb.org/mongo-driver v1.4.3 h1:moga+uhicpVshTyaqY9L23E6QqwcHRUv1sqyOsoyOO8=
 go.mongodb.org/mongo-driver v1.4.3/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
+go.mongodb.org/mongo-driver v1.4.4 h1:bsPHfODES+/yx2PCWzUYMH8xj6PVniPI8DQrsJuSXSs=
+go.mongodb.org/mongo-driver v1.4.4/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -253,6 +260,8 @@ golang.org/x/net v0.0.0-20200602114024-627f9648deb9 h1:pNX+40auqi2JqRfOP1akLGtYc
 golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb h1:eBmm0M9fYhWpKZLjQUUKka/LtIxf46G4fxeEz5KJr9U=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/result_test.go
+++ b/result_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Test AddError() uniqueness
@@ -196,11 +197,11 @@ func TestResult_AsError(t *testing.T) {
 	r.AddErrors(fmt.Errorf("one Error"))
 	r.AddErrors(fmt.Errorf("additional Error"))
 	res := r.AsError()
-	if assert.NotNil(t, res) {
-		assert.Contains(t, res.Error(), "validation failure list:") // Expected from pkg errors
-		assert.Contains(t, res.Error(), "one Error")                // Expected from pkg errors
-		assert.Contains(t, res.Error(), "additional Error")         // Expected from pkg errors
-	}
+	require.NotNil(t, res)
+
+	assert.Contains(t, res.Error(), "validation failure list:") // Expected from pkg errors
+	assert.Contains(t, res.Error(), "one Error")                // Expected from pkg errors
+	assert.Contains(t, res.Error(), "additional Error")         // Expected from pkg errors
 }
 
 // Test methods which suppport a call on a nil instance

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -129,7 +129,9 @@ func testGoSwaggerSpecs(t *testing.T, path string, expectToFail, expectToFailOnL
 	err := filepath.Walk(path,
 		func(path string, info os.FileInfo, err error) error {
 			t.Run(path, func(t *testing.T) {
-				// t.Parallel() // NOTE(fred): cannot use go-openapi in parallel because of global cache pollution
+				if !DebugTest { // when running in dev mode, run serially
+					t.Parallel()
+				}
 
 				npath := filepath.ToSlash(path)
 				shouldNotLoad := expectToFailOnLoad[npath]


### PR DESCRIPTION
* updated dependencies to go-openapi/spec@0.20.0 and go-openapi/loads@0.20.0
* with this update, specs can be safely loaded and validated in parallel

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>