### PR TITLE
Protect against divide-by-zero panic with multipleOf

### DIFF
--- a/values.go
+++ b/values.go
@@ -248,7 +248,7 @@ func MinimumUint(path, in string, data, min uint64, exclusive bool) *errors.Vali
 // MultipleOf validates if the provided number is a multiple of the factor
 func MultipleOf(path, in string, data, factor float64) *errors.Validation {
 	// multipleOf factor must be positive
-	if factor < 0 {
+	if factor <= 0 {
 		return errors.MultipleOfMustBePositive(path, in, factor)
 	}
 	var mult float64
@@ -266,7 +266,7 @@ func MultipleOf(path, in string, data, factor float64) *errors.Validation {
 // MultipleOfInt validates if the provided integer is a multiple of the factor
 func MultipleOfInt(path, in string, data int64, factor int64) *errors.Validation {
 	// multipleOf factor must be positive
-	if factor < 0 {
+	if factor <= 0 {
 		return errors.MultipleOfMustBePositive(path, in, factor)
 	}
 	mult := data / factor
@@ -278,6 +278,10 @@ func MultipleOfInt(path, in string, data int64, factor int64) *errors.Validation
 
 // MultipleOfUint validates if the provided unsigned integer is a multiple of the factor
 func MultipleOfUint(path, in string, data, factor uint64) *errors.Validation {
+	// multipleOf factor must be positive
+	if factor == 0 {
+		return errors.MultipleOfMustBePositive(path, in, factor)
+	}
 	mult := data / factor
 	if mult*factor != data {
 		return errors.NotMultipleOf(path, in, factor, data)

--- a/values_test.go
+++ b/values_test.go
@@ -252,6 +252,13 @@ func TestValuMultipleOf(t *testing.T) {
 	err = MultipleOf("test", "body", 8, 0.2)
 	assert.Nil(t, err)
 
+	// zero
+	err = MultipleOf("test", "body", 9, 0)
+	assert.Error(t, err)
+
+	err = MultipleOf("test", "body", 9.1, 0)
+	assert.Error(t, err)
+
 	// negative
 
 	err = MultipleOf("test", "body", 3, 0.4)
@@ -430,6 +437,18 @@ func TestValues_MultipleOfNative(t *testing.T) {
 	assert.Nil(t, MultipleOfNativeType("path", "in", uint64(5), 1))
 
 	var err *errors.Validation
+
+	err = MultipleOfNativeType("path", "in", int64(5), 0)
+	if assert.NotNil(t, err) {
+		code := int(err.Code())
+		assert.Equal(t, code, int(errors.MultipleOfMustBePositiveCode))
+	}
+
+	err = MultipleOfNativeType("path", "in", uint64(5), 0)
+	if assert.NotNil(t, err) {
+		code := int(err.Code())
+		assert.Equal(t, code, int(errors.MultipleOfMustBePositiveCode))
+	}
 
 	err = MultipleOfNativeType("path", "in", int64(5), -1)
 	if assert.NotNil(t, err) {


### PR DESCRIPTION
Fixes https://github.com/go-openapi/validate/issues/150

MultipleOf already returned errors when evaluating floats (since `x / 0.0` is Inf, which failed the `IsFloat64AJSONInteger` check), so making the int/uint versions return errors as well (instead of panics) was consistent.