### PR TITLE
fix: *string(nil) not equal &string

### DIFF
--- a/values.go
+++ b/values.go
@@ -161,10 +161,22 @@ func ReadOnly(ctx context.Context, path, in string, data interface{}) *errors.Va
 func Required(path, in string, data interface{}) *errors.Validation {
 	val := reflect.ValueOf(data)
 	if val.IsValid() {
-		if reflect.DeepEqual(reflect.Zero(val.Type()).Interface(), val.Interface()) {
-			return errors.Required(path, in, data)
+		typ := reflect.TypeOf(data)
+		switch typ.Kind() {
+		case reflect.Pointer:
+			if val.IsNil() {
+				return errors.Required(path, in, data)
+			}
+			if reflect.DeepEqual(reflect.Zero(val.Elem().Type()).Interface(), val.Elem().Interface()) {
+				return errors.Required(path, in, data)
+			}
+			return nil
+		default:
+			if reflect.DeepEqual(reflect.Zero(val.Type()).Interface(), val.Interface()) {
+				return errors.Required(path, in, data)
+			}
+			return nil
 		}
-		return nil
 	}
 	return errors.Required(path, in, data)
 }

--- a/values_test.go
+++ b/values_test.go
@@ -195,10 +195,26 @@ func TestValues_ValidateRequired(t *testing.T) {
 	path := "test"
 	in := "body"
 
+	emptyString := ""
+	emptyStringStruct := struct {
+		A *string
+	}{
+		A: &emptyString,
+	}
+
+	emptyNumber := 0
+	emptyNumberStruct := struct {
+		A *int
+	}{
+		A: &emptyNumber,
+	}
+
 	RequiredFail := []interface{}{
 		"",
 		0,
 		nil,
+		emptyStringStruct.A,
+		emptyNumberStruct.A,
 	}
 
 	for _, v := range RequiredFail {
@@ -206,11 +222,27 @@ func TestValues_ValidateRequired(t *testing.T) {
 		assert.Error(t, err)
 	}
 
+	notEmptyString := "bla"
+	notEmptyStringStruct := struct {
+		A *string
+	}{
+		A: &notEmptyString,
+	}
+
+	notEmptyNumber := 1
+	notEmptyNumberStruct := struct {
+		A *int
+	}{
+		A: &notEmptyNumber,
+	}
+
 	RequiredSuccess := []interface{}{
 		" ",
 		"bla-bla-bla",
 		2,
 		[]interface{}{21, []int{}, "testString"},
+		notEmptyStringStruct.A,
+		notEmptyNumberStruct.A,
 	}
 
 	for _, v := range RequiredSuccess {


### PR DESCRIPTION
fix: *string(nil) not equal &string("")

```go
func TestRequired(t *testing.T) {
	empty := ""
	a := struct {
		A *string
	}{
		A: &empty,
	}
	t.Log(Required("A", "a", a.A))
	t.Log(BeforeRequired("A", "a", a.A))
}
```
```log
=== RUN   TestRequired
    require_test.go:14: A in a is required
    require_test.go:15: <nil>
--- PASS: TestRequired (0.00s)
PASS
```