### PR TITLE
Validation Option to disable strict path parameter uniqueness validation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -33,7 +33,7 @@ Reported as errors:
 
 	[x] definition can't declare a property that's already defined by one of its ancestors
 	[x] definition's ancestor can't be a descendant of the same model
-	[x] path uniqueness: each api path should be non-verbatim (account for path param names) unique per method
+	[x] path uniqueness: each api path should be non-verbatim (account for path param names) unique per method. Validation can be laxed by disabling StrictPathParamUniqueness.
 	[x] each security reference should contain only unique scopes
 	[x] each security scope in a security definition should be unique
 	[x] parameters in path must be unique

--- a/options.go
+++ b/options.go
@@ -21,10 +21,28 @@ import "sync"
 // NOTE: other options might be needed, for example a go-swagger specific mode.
 type Opts struct {
 	ContinueOnErrors bool // true: continue reporting errors, even if spec is invalid
+
+	// StrictPathParamUniqueness enables a strict validation of paths that include
+	// path parameters. When true, it will enforce that for each method, the path
+	// is unique, regardless of path parameters such that GET:/petstore/{id} and
+	// GET:/petstore/{pet} anre considered duplicate paths.
+	//
+	// Consider disabling if path parameters can include slashes such as
+	// GET:/v1/{shelve} and GET:/v1/{book}, where the IDs are "shelve/*" and
+	// /"shelve/*/book/*" respectively.
+	StrictPathParamUniqueness bool
 }
 
 var (
-	defaultOpts      = Opts{ContinueOnErrors: false} // default is to stop validation on errors
+	defaultOpts = Opts{
+		// default is to stop validation on errors
+		ContinueOnErrors: false,
+
+		// StrictPathParamUniqueness is defaulted to true. This maintains existing
+		// behavior.
+		StrictPathParamUniqueness: true,
+	}
+
 	defaultOptsMutex = &sync.Mutex{}
 )
 

--- a/spec_test.go
+++ b/spec_test.go
@@ -451,6 +451,11 @@ func TestSpec_ValidateParameters(t *testing.T) {
 	assert.Len(t, res.Errors, 1)
 	assert.Contains(t, res.Errors[0].Error(), "overlaps with")
 
+	// Disable strict path param uniqueness and ensure there is no error
+	validator.Options.StrictPathParamUniqueness = false
+	res = validator.validateParameters()
+	assert.Empty(t, res.Errors)
+
 	doc, _ = loads.Analyzed(PetStoreJSONMessage, "")
 	validator = NewSpecValidator(spec.MustLoadSwagger20Schema(), strfmt.Default)
 	validator.spec = doc


### PR DESCRIPTION
Adds a validation option to disable path uniqueness validation behavior where path parameters are ignored. The existing behavior of the validator replaces path parameters with an X and then checks for uniqueness. 

As an example, the two paths `GET /v1/{book}` and `GET /v1/{shelve}` where `book` has the pattern `shelves/*/book/*` and `shelve` has the pattern `shelve/*`, get both replaced to `/v1/X` and an error is returned reporting overlapping paths.

This does not allow the [resource name pattern described by Google's AIPs](https://cloud.google.com/apis/design/resource_names). Further, I do not see it being described in the [specification](https://swagger.io/docs/specification/describing-parameters/) that the path parameters can not have slashes and thus the path can be unique based on the required path parameter.

I will add that I tested other Swagger validators / code generators and they were perfectly happy with paths that are only unique based on unique path parameters.