### PR TITLE
perf(validators): reduced GC pressure

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -2,7 +2,7 @@
 
 Validating the Kubernetes Swagger API
 
-v0.22.6: 60,000,000 allocs
+## v0.22.6: 60,000,000 allocs
 ```
 goos: linux
 goarch: amd64
@@ -11,7 +11,7 @@ cpu: AMD Ryzen 7 5800X 8-Core Processor
 Benchmark_KubernetesSpec/validating_kubernetes_API-16         	       1	8549863982 ns/op	7067424936 B/op	59583275 allocs/op
 ```
 
-After refact PR: minor but noticable improvements: 25,000,000 allocs
+## After refact PR: minor but noticable improvements: 25,000,000 allocs
 ```
 go test -bench Spec
 goos: linux
@@ -19,4 +19,13 @@ goarch: amd64
 pkg: github.com/go-openapi/validate
 cpu: AMD Ryzen 7 5800X 8-Core Processor
 Benchmark_KubernetesSpec/validating_kubernetes_API-16         	       1	4064535557 ns/op	3379715592 B/op	25320330 allocs/op
+```
+
+## After reduce GC pressure PR: 17,000,000 allocs
+```
+goos: linux
+goarch: amd64
+pkg: github.com/go-openapi/validate
+cpu: AMD Ryzen 7 5800X 8-Core Processor             
+Benchmark_KubernetesSpec/validating_kubernetes_API-16         	       1	3758414145 ns/op	2593881496 B/op	17111373 allocs/op
 ```

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -21,6 +21,7 @@ func Benchmark_KubernetesSpec(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			validator := NewSpecValidator(doc.Schema(), strfmt.Default)
+			validator.Options.SkipSchemataResult = true
 			res, _ := validator.Validate(doc)
 			if res == nil || !res.IsValid() {
 				b.FailNow()

--- a/fixtures/bugs/2649/swagger.yaml
+++ b/fixtures/bugs/2649/swagger.yaml
@@ -1,0 +1,5696 @@
+basePath: /
+definitions:
+    EmojiUpdateType:
+        title: EmojiUpdateType models an admin update action to take on a custom emoji.
+        type: string
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    InstanceConfigurationEmojis:
+        properties:
+            emoji_size_limit:
+                description: Max allowed emoji image size in bytes.
+                example: 51200
+                format: int64
+                type: integer
+                x-go-name: EmojiSizeLimit
+        title: InstanceConfigurationEmojis models instance emoji config parameters.
+        type: object
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    Link:
+        description: See https://webfinger.net/
+        properties:
+            href:
+                type: string
+                x-go-name: Href
+            rel:
+                type: string
+                x-go-name: Rel
+            template:
+                type: string
+                x-go-name: Template
+            type:
+                type: string
+                x-go-name: Type
+        title: Link represents one 'link' in a slice of links returned from a lookup request.
+        type: object
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    Mention:
+        properties:
+            acct:
+                description: |-
+                    The account URI as discovered via webfinger.
+                    Equal to username for local users, or username@domain for remote users.
+                example: some_user@example.org
+                type: string
+                x-go-name: Acct
+            id:
+                description: The ID of the mentioned account.
+                example: 01FBYJHQWQZAVWFRK9PDYTKGMB
+                type: string
+                x-go-name: ID
+            url:
+                description: The web URL of the mentioned account's profile.
+                example: https://example.org/@some_user
+                type: string
+                x-go-name: URL
+            username:
+                description: The username of the mentioned account.
+                example: some_user
+                type: string
+                x-go-name: Username
+        title: Mention represents a mention of another account.
+        type: object
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    NodeInfoServices:
+        properties:
+            inbound:
+                items:
+                    type: string
+                type: array
+                x-go-name: Inbound
+            outbound:
+                items:
+                    type: string
+                type: array
+                x-go-name: Outbound
+        title: NodeInfoServices represents inbound and outbound services that this node offers connections to.
+        type: object
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    NodeInfoSoftware:
+        properties:
+            name:
+                example: gotosocial
+                type: string
+                x-go-name: Name
+            version:
+                example: 0.1.2 1234567
+                type: string
+                x-go-name: Version
+        title: NodeInfoSoftware represents the name and version number of the software of this node.
+        type: object
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    NodeInfoUsage:
+        properties:
+            localPosts:
+                format: int64
+                type: integer
+                x-go-name: LocalPosts
+            users:
+                $ref: '#/definitions/NodeInfoUsers'
+        title: NodeInfoUsage represents usage information about this server, such as number of users.
+        type: object
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    NodeInfoUsers:
+        properties:
+            total:
+                format: int64
+                type: integer
+                x-go-name: Total
+        title: NodeInfoUsers represents aggregate information about the users on the server.
+        type: object
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    Source:
+        description: Returned as an additional entity when verifying and updated credentials, as an attribute of Account.
+        properties:
+            fields:
+                description: Metadata about the account.
+                items:
+                    $ref: '#/definitions/field'
+                type: array
+                x-go-name: Fields
+            follow_requests_count:
+                description: The number of pending follow requests.
+                format: int64
+                type: integer
+                x-go-name: FollowRequestsCount
+            language:
+                description: The default posting language for new statuses.
+                type: string
+                x-go-name: Language
+            note:
+                description: Profile bio.
+                type: string
+                x-go-name: Note
+            privacy:
+                description: |-
+                    The default post privacy to be used for new statuses.
+                    public = Public post
+                    unlisted = Unlisted post
+                    private = Followers-only post
+                    direct = Direct post
+                type: string
+                x-go-name: Privacy
+            sensitive:
+                description: Whether new statuses should be marked sensitive by default.
+                type: boolean
+                x-go-name: Sensitive
+            status_format:
+                description: The default posting format for new statuses.
+                type: string
+                x-go-name: StatusFormat
+        title: Source represents display or publishing preferences of user's own account.
+        type: object
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    account:
+        description: The modelled account can be either a remote account, or one on this instance.
+        properties:
+            acct:
+                description: |-
+                    The account URI as discovered via webfinger.
+                    Equal to username for local users, or username@domain for remote users.
+                example: some_user@example.org
+                type: string
+                x-go-name: Acct
+            avatar:
+                description: Web location of the account's avatar.
+                example: https://example.org/media/some_user/avatar/original/avatar.jpeg
+                type: string
+                x-go-name: Avatar
+            avatar_static:
+                description: |-
+                    Web location of a static version of the account's avatar.
+                    Only relevant when the account's main avatar is a video or a gif.
+                example: https://example.org/media/some_user/avatar/static/avatar.png
+                type: string
+                x-go-name: AvatarStatic
+            bot:
+                description: Account identifies as a bot.
+                type: boolean
+                x-go-name: Bot
+            created_at:
+                description: When the account was created (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: CreatedAt
+            custom_css:
+                description: CustomCSS to include when rendering this account's profile or statuses.
+                type: string
+                x-go-name: CustomCSS
+            discoverable:
+                description: Account has opted into discovery features.
+                type: boolean
+                x-go-name: Discoverable
+            display_name:
+                description: The account's display name.
+                example: big jeff (he/him)
+                type: string
+                x-go-name: DisplayName
+            emojis:
+                description: Array of custom emojis used in this account's note or display name.
+                items:
+                    $ref: '#/definitions/emoji'
+                type: array
+                x-go-name: Emojis
+            enable_rss:
+                description: Account has enabled RSS feed.
+                type: boolean
+                x-go-name: EnableRSS
+            fields:
+                description: Additional metadata attached to this account's profile.
+                items:
+                    $ref: '#/definitions/field'
+                type: array
+                x-go-name: Fields
+            followers_count:
+                description: Number of accounts following this account, according to our instance.
+                format: int64
+                type: integer
+                x-go-name: FollowersCount
+            following_count:
+                description: Number of account's followed by this account, according to our instance.
+                format: int64
+                type: integer
+                x-go-name: FollowingCount
+            header:
+                description: Web location of the account's header image.
+                example: https://example.org/media/some_user/header/original/header.jpeg
+                type: string
+                x-go-name: Header
+            header_static:
+                description: |-
+                    Web location of a static version of the account's header.
+                    Only relevant when the account's main header is a video or a gif.
+                example: https://example.org/media/some_user/header/static/header.png
+                type: string
+                x-go-name: HeaderStatic
+            id:
+                description: The account id.
+                example: 01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: ID
+            last_status_at:
+                description: When the account's most recent status was posted (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: LastStatusAt
+            locked:
+                description: Account manually approves follow requests.
+                type: boolean
+                x-go-name: Locked
+            mute_expires_at:
+                description: If this account has been muted, when will the mute expire (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: MuteExpiresAt
+            note:
+                description: Bio/description of this account.
+                type: string
+                x-go-name: Note
+            role:
+                $ref: '#/definitions/accountRole'
+            source:
+                $ref: '#/definitions/Source'
+            statuses_count:
+                description: Number of statuses posted by this account, according to our instance.
+                format: int64
+                type: integer
+                x-go-name: StatusesCount
+            suspended:
+                description: Account has been suspended by our instance.
+                type: boolean
+                x-go-name: Suspended
+            url:
+                description: Web location of the account's profile page.
+                example: https://example.org/@some_user
+                type: string
+                x-go-name: URL
+            username:
+                description: The username of the account, not including domain.
+                example: some_user
+                type: string
+                x-go-name: Username
+        title: Account models a fediverse account.
+        type: object
+        x-go-name: Account
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    accountRelationship:
+        properties:
+            blocked_by:
+                description: This account is blocking you.
+                type: boolean
+                x-go-name: BlockedBy
+            blocking:
+                description: You are blocking this account.
+                type: boolean
+                x-go-name: Blocking
+            domain_blocking:
+                description: You are blocking this account's domain.
+                type: boolean
+                x-go-name: DomainBlocking
+            endorsed:
+                description: You are featuring this account on your profile.
+                type: boolean
+                x-go-name: Endorsed
+            followed_by:
+                description: This account follows you.
+                type: boolean
+                x-go-name: FollowedBy
+            following:
+                description: You are following this account.
+                type: boolean
+                x-go-name: Following
+            id:
+                description: The account id.
+                example: 01FBW9XGEP7G6K88VY4S9MPE1R
+                type: string
+                x-go-name: ID
+            muting:
+                description: You are muting this account.
+                type: boolean
+                x-go-name: Muting
+            muting_notifications:
+                description: You are muting notifications from this account.
+                type: boolean
+                x-go-name: MutingNotifications
+            note:
+                description: Your note on this account.
+                type: string
+                x-go-name: Note
+            notifying:
+                description: You are seeing notifications when this account posts.
+                type: boolean
+                x-go-name: Notifying
+            requested:
+                description: You have requested to follow this account, and the request is pending.
+                type: boolean
+                x-go-name: Requested
+            showing_reblogs:
+                description: You are seeing reblogs/boosts from this account in your home timeline.
+                type: boolean
+                x-go-name: ShowingReblogs
+        title: Relationship represents a relationship between accounts.
+        type: object
+        x-go-name: Relationship
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    accountRole:
+        properties:
+            name:
+                type: string
+                x-go-name: Name
+        title: AccountRole models the role of an account.
+        type: object
+        x-go-name: AccountRole
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    adminAccountInfo:
+        properties:
+            account:
+                $ref: '#/definitions/account'
+            approved:
+                description: Whether the account is currently approved.
+                type: boolean
+                x-go-name: Approved
+            confirmed:
+                description: Whether the account has confirmed their email address.
+                type: boolean
+                x-go-name: Confirmed
+            created_at:
+                description: When the account was first discovered. (ISO 8601 Datetime)
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: CreatedAt
+            created_by_application_id:
+                description: The ID of the application that created this account.
+                type: string
+                x-go-name: CreatedByApplicationID
+            disabled:
+                description: Whether the account is currently disabled.
+                type: boolean
+                x-go-name: Disabled
+            domain:
+                description: |-
+                    The domain of the account.
+                    Null for local accounts.
+                example: example.org
+                type: string
+                x-go-name: Domain
+            email:
+                description: |-
+                    The email address associated with the account.
+                    Empty string for remote accounts or accounts with
+                    no known email address.
+                example: someone@somewhere.com
+                type: string
+                x-go-name: Email
+            id:
+                description: The ID of the account in the database.
+                example: 01GQ4PHNT622DQ9X95XQX4KKNR
+                type: string
+                x-go-name: ID
+            invite_request:
+                description: |-
+                    The reason given when requesting an invite.
+                    Null if not known / remote account.
+                example: Pleaaaaaaaaaaaaaaase!!
+                type: string
+                x-go-name: InviteRequest
+            invited_by_account_id:
+                description: The ID of the account that invited this user
+                type: string
+                x-go-name: InvitedByAccountID
+            ip:
+                description: |-
+                    The IP address last used to login to this account.
+                    Null if not known.
+                example: 192.0.2.1
+                type: string
+                x-go-name: IP
+            ips:
+                description: |-
+                    All known IP addresses associated with this account.
+                    NOT IMPLEMENTED (will always be empty array).
+                example: []
+                items: {}
+                type: array
+                x-go-name: IPs
+            locale:
+                description: The locale of the account. (ISO 639 Part 1 two-letter language code)
+                example: en
+                type: string
+                x-go-name: Locale
+            role:
+                $ref: '#/definitions/accountRole'
+            silenced:
+                description: Whether the account is currently silenced
+                type: boolean
+                x-go-name: Silenced
+            suspended:
+                description: Whether the account is currently suspended.
+                type: boolean
+                x-go-name: Suspended
+            username:
+                description: The username of the account.
+                example: dril
+                type: string
+                x-go-name: Username
+        title: AdminAccountInfo models the admin view of an account's details.
+        type: object
+        x-go-name: AdminAccountInfo
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    adminEmojiCategory:
+      description: Used for sorting custom emoji in the picker.
+      example: blobcats
+      type: string
+      x-go-name: Category
+    adminEmoji:
+        properties:
+            category:
+                $ref: '#/definitions/adminEmojiCategory'
+            content_type:
+                description: The MIME content type of the emoji.
+                example: image/png
+                type: string
+                x-go-name: ContentType
+            disabled:
+                description: True if this emoji has been disabled by an admin action.
+                example: false
+                type: boolean
+                x-go-name: Disabled
+            domain:
+                description: The domain from which the emoji originated. Only defined for remote domains, otherwise key will not be set.
+                example: example.org
+                type: string
+                x-go-name: Domain
+            id:
+                description: The ID of the emoji.
+                example: 01GEM7SFDZ7GZNRXFVZ3X4E4N1
+                type: string
+                x-go-name: ID
+            shortcode:
+                description: The name of the custom emoji.
+                example: blobcat_uwu
+                type: string
+                x-go-name: Shortcode
+            static_url:
+                description: A link to a static copy of the custom emoji.
+                example: https://example.org/fileserver/emojis/blogcat_uwu.png
+                type: string
+                x-go-name: StaticURL
+            total_file_size:
+                description: The total file size taken up by the emoji in bytes, including static and animated versions.
+                example: 69420
+                format: int64
+                type: integer
+                x-go-name: TotalFileSize
+            updated_at:
+                description: Time when the emoji image was last updated.
+                example: "2022-10-05T09:21:26.419Z"
+                type: string
+                x-go-name: UpdatedAt
+            uri:
+                description: The ActivityPub URI of the emoji.
+                example: https://example.org/emojis/016T5Q3SQKBT337DAKVSKNXXW1
+                type: string
+                x-go-name: URI
+            url:
+                description: Web URL of the custom emoji.
+                example: https://example.org/fileserver/emojis/blogcat_uwu.gif
+                type: string
+                x-go-name: URL
+            visible_in_picker:
+                description: Emoji is visible in the emoji picker of the instance.
+                example: true
+                type: boolean
+                x-go-name: VisibleInPicker
+        title: AdminEmoji models the admin view of a custom emoji.
+        type: object
+        x-go-name: AdminEmoji
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    adminReport:
+        properties:
+            account:
+                $ref: '#/definitions/adminAccountInfo'
+            action_taken:
+                description: Whether an action has been taken by an admin in response to this report.
+                example: false
+                type: boolean
+                x-go-name: ActionTaken
+            action_taken_at:
+                description: |-
+                    If an action was taken, at what time was this done? (ISO 8601 Datetime)
+                    Will be null if not set / no action yet taken.
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: ActionTakenAt
+            action_taken_by_account:
+                $ref: '#/definitions/adminAccountInfo'
+            action_taken_comment:
+                description: |-
+                    If an action was taken, what comment was made by the admin on the taken action?
+                    Will be null if not set / no action yet taken.
+                example: Account was suspended.
+                type: string
+                x-go-name: ActionTakenComment
+            assigned_account:
+                $ref: '#/definitions/adminAccountInfo'
+            category:
+                description: Under what category was this report created?
+                example: spam
+                type: string
+                x-go-name: Category
+            comment:
+                description: |-
+                    Comment submitted when the report was created.
+                    Will be empty if no comment was submitted.
+                example: This person has been harassing me.
+                type: string
+                x-go-name: Comment
+            created_at:
+                description: The date when this report was created (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: CreatedAt
+            forwarded:
+                description: Bool to indicate that report should be federated to remote instance.
+                example: true
+                type: boolean
+                x-go-name: Forwarded
+            id:
+                description: ID of the report.
+                example: 01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: ID
+            rule_ids:
+                description: |-
+                    Array of rule IDs that were submitted along with this report.
+                    NOT IMPLEMENTED, will always be empty array.
+                items: {}
+                type: array
+                x-go-name: Rules
+            statuses:
+                description: |-
+                    Array of  statuses that were submitted along with this report.
+                    Will be empty if no status IDs were submitted with the report.
+                items:
+                    $ref: '#/definitions/status'
+                type: array
+                x-go-name: Statuses
+            target_account:
+                $ref: '#/definitions/adminAccountInfo'
+            updated_at:
+                description: Time of last action on this report (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: UpdatedAt
+        title: AdminReport models the admin view of a report.
+        type: object
+        x-go-name: AdminReport
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    advancedVisibilityFlagsForm:
+        description: |-
+            AdvancedVisibilityFlagsForm allows a few more advanced flags to be set on new statuses, in addition
+            to the standard mastodon-compatible ones.
+        properties:
+            boostable:
+                description: This status can be boosted/reblogged.
+                type: boolean
+                x-go-name: Boostable
+            federated:
+                description: This status will be federated beyond the local timeline(s).
+                type: boolean
+                x-go-name: Federated
+            likeable:
+                description: This status can be liked/faved.
+                type: boolean
+                x-go-name: Likeable
+            replyable:
+                description: This status can be replied to.
+                type: boolean
+                x-go-name: Replyable
+        type: object
+        x-go-name: AdvancedVisibilityFlagsForm
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    announcement:
+        properties:
+            all_day:
+                description: Announcement doesn't have begin time and end time, but begin day and end day.
+                type: boolean
+                x-go-name: AllDay
+            content:
+                description: |-
+                    The body of the announcement.
+                    Should be HTML formatted.
+                example: <p>This is an announcement. No malarky.</p>
+                type: string
+                x-go-name: Content
+            emoji:
+                description: Emojis used in this announcement.
+                items:
+                    $ref: '#/definitions/emoji'
+                type: array
+                x-go-name: Emojis
+            ends_at:
+                description: |-
+                    When the announcement should stop being displayed (ISO 8601 Datetime).
+                    If the announcement has no end time, this will be omitted or empty.
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: EndsAt
+            id:
+                description: The ID of the announcement.
+                example: 01FC30T7X4TNCZK0TH90QYF3M4
+                type: string
+                x-go-name: ID
+            mentions:
+                description: Mentions this announcement contains.
+                items:
+                    $ref: '#/definitions/Mention'
+                type: array
+                x-go-name: Mentions
+            published:
+                description: |-
+                    Announcement is 'published', ie., visible to users.
+                    Announcements that are not published should be shown only to admins.
+                type: boolean
+                x-go-name: Published
+            published_at:
+                description: When the announcement was first published (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: PublishedAt
+            reactions:
+                description: Reactions to this announcement.
+                items:
+                    $ref: '#/definitions/announcementReaction'
+                type: array
+                x-go-name: Reactions
+            read:
+                description: Requesting account has seen this announcement.
+                type: boolean
+                x-go-name: Read
+            starts_at:
+                description: |-
+                    When the announcement should begin to be displayed (ISO 8601 Datetime).
+                    If the announcement has no start time, this will be omitted or empty.
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: StartsAt
+            statuses:
+                description: Statuses contained in this announcement.
+                items:
+                    $ref: '#/definitions/status'
+                type: array
+                x-go-name: Statuses
+            tags:
+                description: Tags used in this announcement.
+                items:
+                    $ref: '#/definitions/tag'
+                type: array
+                x-go-name: Tags
+            updated_at:
+                description: When the announcement was last updated (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: UpdatedAt
+        title: Announcement models an admin announcement for the instance.
+        type: object
+        x-go-name: Announcement
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    announcementReaction:
+        properties:
+            count:
+                description: The total number of users who have added this reaction.
+                example: 5
+                format: int64
+                type: integer
+                x-go-name: Count
+            me:
+                description: This reaction belongs to the account viewing it.
+                type: boolean
+                x-go-name: Me
+            name:
+                description: The emoji used for the reaction. Either a unicode emoji, or a custom emoji's shortcode.
+                example: blobcat_uwu
+                type: string
+                x-go-name: Name
+            static_url:
+                description: |-
+                    Web link to a non-animated image of the custom emoji.
+                    Empty for unicode emojis.
+                example: https://example.org/custom_emojis/statuc/blobcat_uwu.png
+                type: string
+                x-go-name: StaticURL
+            url:
+                description: |-
+                    Web link to the image of the custom emoji.
+                    Empty for unicode emojis.
+                example: https://example.org/custom_emojis/original/blobcat_uwu.png
+                type: string
+                x-go-name: URL
+        title: AnnouncementReaction models a user reaction to an announcement.
+        type: object
+        x-go-name: AnnouncementReaction
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    application:
+        properties:
+            client_id:
+                description: Client ID associated with this application.
+                type: string
+                x-go-name: ClientID
+            client_secret:
+                description: Client secret associated with this application.
+                type: string
+                x-go-name: ClientSecret
+            id:
+                description: The ID of the application.
+                example: 01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: ID
+            name:
+                description: The name of the application.
+                example: Tusky
+                type: string
+                x-go-name: Name
+            redirect_uri:
+                description: Post-authorization redirect URI for the application (OAuth2).
+                example: https://example.org/callback?some=query
+                type: string
+                x-go-name: RedirectURI
+            vapid_key:
+                description: Push API key for this application.
+                type: string
+                x-go-name: VapidKey
+            website:
+                description: The website associated with the application (url)
+                example: https://tusky.app
+                type: string
+                x-go-name: Website
+        title: Application models an api application.
+        type: object
+        x-go-name: Application
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    attachment:
+        properties:
+            blurhash:
+                description: |-
+                    A hash computed by the BlurHash algorithm, for generating colorful preview thumbnails when media has not been downloaded yet.
+                    See https://github.com/woltapp/blurhash
+                type: string
+                x-go-name: Blurhash
+            description:
+                description: Alt text that describes what is in the media attachment.
+                example: This is a picture of a kitten.
+                type: string
+                x-go-name: Description
+            id:
+                description: The ID of the attachment.
+                example: 01FC31DZT1AYWDZ8XTCRWRBYRK
+                type: string
+                x-go-name: ID
+            meta:
+                $ref: '#/definitions/mediaMeta'
+            preview_remote_url:
+                description: |-
+                    The location of a scaled-down preview of the attachment on the remote server.
+                    Only defined for instances other than our own.
+                example: https://some-other-server.org/attachments/small/ahhhhh.jpeg
+                type: string
+                x-go-name: PreviewRemoteURL
+            preview_url:
+                description: The location of a scaled-down preview of the attachment.
+                example: https://example.org/fileserver/some_id/attachments/some_id/small/attachment.jpeg
+                type: string
+                x-go-name: PreviewURL
+            remote_url:
+                description: |-
+                    The location of the full-size original attachment on the remote server.
+                    Only defined for instances other than our own.
+                example: https://some-other-server.org/attachments/original/ahhhhh.jpeg
+                type: string
+                x-go-name: RemoteURL
+            text_url:
+                description: |-
+                    A shorter URL for the attachment.
+                    In our case, we just give the URL again since we don't create smaller URLs.
+                type: string
+                x-go-name: TextURL
+            type:
+                description: The type of the attachment.
+                example: image
+                type: string
+                x-go-name: Type
+            url:
+                description: The location of the original full-size attachment.
+                example: https://example.org/fileserver/some_id/attachments/some_id/original/attachment.jpeg
+                type: string
+                x-go-name: URL
+        title: Attachment models a media attachment.
+        type: object
+        x-go-name: Attachment
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    card:
+        properties:
+            author_name:
+                description: The author of the original resource.
+                example: weewee@buzzfeed.com
+                type: string
+                x-go-name: AuthorName
+            author_url:
+                description: A link to the author of the original resource.
+                example: https://buzzfeed.com/authors/weewee
+                type: string
+                x-go-name: AuthorURL
+            blurhash:
+                description: A hash computed by the BlurHash algorithm, for generating colorful preview thumbnails when media has not been downloaded yet.
+                type: string
+                x-go-name: Blurhash
+            description:
+                description: Description of preview.
+                example: Is water wet? We're not sure. In this article, we ask an expert...
+                type: string
+                x-go-name: Description
+            embed_url:
+                description: Used for photo embeds, instead of custom html.
+                type: string
+                x-go-name: EmbedURL
+            height:
+                description: Height of preview, in pixels.
+                format: int64
+                type: integer
+                x-go-name: Height
+            html:
+                description: HTML to be used for generating the preview card.
+                type: string
+                x-go-name: HTML
+            image:
+                description: Preview thumbnail.
+                example: https://example.org/fileserver/preview/thumb.jpg
+                type: string
+                x-go-name: Image
+            provider_name:
+                description: The provider of the original resource.
+                example: Buzzfeed
+                type: string
+                x-go-name: ProviderName
+            provider_url:
+                description: A link to the provider of the original resource.
+                example: https://buzzfeed.com
+                type: string
+                x-go-name: ProviderURL
+            title:
+                description: Title of linked resource.
+                example: Buzzfeed - Is Water Wet?
+                type: string
+                x-go-name: Title
+            type:
+                description: The type of the preview card.
+                example: link
+                type: string
+                x-go-name: Type
+            url:
+                description: Location of linked resource.
+                example: https://buzzfeed.com/some/fuckin/buzzfeed/article
+                type: string
+                x-go-name: URL
+            width:
+                description: Width of preview, in pixels.
+                format: int64
+                type: integer
+                x-go-name: Width
+        title: Card represents a rich preview card that is generated using OpenGraph tags from a URL.
+        type: object
+        x-go-name: Card
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    domain:
+        description: Domain represents a remote domain
+        properties:
+            domain:
+                description: The hostname of the domain.
+                example: example.org
+                type: string
+                x-go-name: Domain
+            public_comment:
+                description: If the domain is blocked, what's the publicly-stated reason for the block.
+                example: they smell
+                type: string
+                x-go-name: PublicComment
+            silenced_at:
+                description: Time at which this domain was silenced. Key will not be present on open domains.
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: SilencedAt
+            suspended_at:
+                description: Time at which this domain was suspended. Key will not be present on open domains.
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: SuspendedAt
+        type: object
+        x-go-name: Domain
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    domainBlock:
+        description: DomainBlock represents a block on one domain
+        properties:
+            created_at:
+                description: Time at which this block was created (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: CreatedAt
+            created_by:
+                description: ID of the account that created this domain block.
+                example: 01FBW2758ZB6PBR200YPDDJK4C
+                type: string
+                x-go-name: CreatedBy
+            domain:
+                description: The hostname of the domain.
+                example: example.org
+                type: string
+                x-go-name: Domain
+            id:
+                description: The ID of the domain block.
+                example: 01FBW21XJA09XYX51KV5JVBW0F
+                readOnly: true
+                type: string
+                x-go-name: ID
+            obfuscate:
+                description: |-
+                    Obfuscate the domain name when serving this domain block publicly.
+                    A useful anti-harassment tool.
+                example: false
+                type: boolean
+                x-go-name: Obfuscate
+            private_comment:
+                description: Private comment for this block, visible to our instance admins only.
+                example: they are poopoo
+                type: string
+                x-go-name: PrivateComment
+            public_comment:
+                description: If the domain is blocked, what's the publicly-stated reason for the block.
+                example: they smell
+                type: string
+                x-go-name: PublicComment
+            silenced_at:
+                description: Time at which this domain was silenced. Key will not be present on open domains.
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: SilencedAt
+            subscription_id:
+                description: The ID of the subscription that created/caused this domain block.
+                example: 01FBW25TF5J67JW3HFHZCSD23K
+                type: string
+                x-go-name: SubscriptionID
+            suspended_at:
+                description: Time at which this domain was suspended. Key will not be present on open domains.
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: SuspendedAt
+        type: object
+        x-go-name: DomainBlock
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    domainBlockCreateRequest:
+        properties:
+            domain:
+                description: hostname/domain to block
+                type: string
+                x-go-name: Domain
+            domains:
+                description: A list of domains to block. Only used if import=true is specified.
+                x-go-name: Domains
+            obfuscate:
+                description: whether the domain should be obfuscated when being displayed publicly
+                type: boolean
+                x-go-name: Obfuscate
+            private_comment:
+                description: private comment for other admins on why the domain was blocked
+                type: string
+                x-go-name: PrivateComment
+            public_comment:
+                description: public comment on the reason for the domain block
+                type: string
+                x-go-name: PublicComment
+        title: DomainBlockCreateRequest is the form submitted as a POST to /api/v1/admin/domain_blocks to create a new block.
+        type: object
+        x-go-name: DomainBlockCreateRequest
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    emoji:
+        properties:
+            category:
+                description: Used for sorting custom emoji in the picker.
+                example: blobcats
+                type: string
+                x-go-name: Category
+            shortcode:
+                description: The name of the custom emoji.
+                example: blobcat_uwu
+                type: string
+                x-go-name: Shortcode
+            static_url:
+                description: A link to a static copy of the custom emoji.
+                example: https://example.org/fileserver/emojis/blogcat_uwu.png
+                type: string
+                x-go-name: StaticURL
+            url:
+                description: Web URL of the custom emoji.
+                example: https://example.org/fileserver/emojis/blogcat_uwu.gif
+                type: string
+                x-go-name: URL
+            visible_in_picker:
+                description: Emoji is visible in the emoji picker of the instance.
+                example: true
+                type: boolean
+                x-go-name: VisibleInPicker
+        title: Emoji represents a custom emoji.
+        type: object
+        x-go-name: Emoji
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    emojiCategory:
+        properties:
+            id:
+                description: The ID of the custom emoji category.
+                type: string
+                x-go-name: ID
+            name:
+                description: The name of the custom emoji category.
+                type: string
+                x-go-name: Name
+        title: EmojiCategory represents a custom emoji category.
+        type: object
+        x-go-name: EmojiCategory
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    emojiCreateRequest:
+        properties:
+            CategoryName:
+                description: |-
+                    Category in which to place the new emoji. Will be uncategorized by default.
+                    CategoryName length should not exceed 64 characters.
+                type: string
+            Image:
+                description: Image file to use for the emoji. Must be png or gif and no larger than 50kb.
+            Shortcode:
+                description: Desired shortcode for the emoji, without surrounding colons. This must be unique for the domain.
+                example: blobcat_uwu
+                type: string
+        title: EmojiCreateRequest represents a request to create a custom emoji made through the admin API.
+        type: object
+        x-go-name: EmojiCreateRequest
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    emojiUpdateRequest:
+        properties:
+            CategoryName:
+                description: Category in which to place the emoji.
+                type: string
+            Image:
+                description: |-
+                    Image file to use for the emoji.
+                    Must be png or gif and no larger than 50kb.
+            Shortcode:
+                description: Desired shortcode for the emoji, without surrounding colons. This must be unique for the domain.
+                example: blobcat_uwu
+                type: string
+            type:
+                $ref: '#/definitions/EmojiUpdateType'
+        title: EmojiUpdateRequest represents a request to update a custom emoji, made through the admin API.
+        type: object
+        x-go-name: EmojiUpdateRequest
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    field:
+        properties:
+            name:
+                description: The key/name of this field.
+                example: pronouns
+                type: string
+                x-go-name: Name
+            value:
+                description: The value of this field.
+                example: they/them
+                type: string
+                x-go-name: Value
+            verified_at:
+                description: If this field has been verified, when did this occur? (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: VerifiedAt
+        title: Field represents a name/value pair to display on an account's profile.
+        type: object
+        x-go-name: Field
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceConfigurationAccounts:
+        properties:
+            allow_custom_css:
+                description: Whether or not accounts on this instance are allowed to upload custom CSS for profiles and statuses.
+                example: false
+                type: boolean
+                x-go-name: AllowCustomCSS
+            max_featured_tags:
+                description: |-
+                    The maximum number of featured tags allowed for each account.
+                    Currently not implemented, so this is hardcoded to 10.
+                format: int64
+                type: integer
+                x-go-name: MaxFeaturedTags
+        title: InstanceConfigurationAccounts models instance account config parameters.
+        type: object
+        x-go-name: InstanceConfigurationAccounts
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceConfigurationMediaAttachments:
+        properties:
+            image_matrix_limit:
+                description: |-
+                    Max allowed image size in pixels as height*width.
+
+                    GtS doesn't set a limit on this, but for compatibility
+                    we give Mastodon's 4096x4096px value here.
+                example: 16777216
+                format: int64
+                type: integer
+                x-go-name: ImageMatrixLimit
+            image_size_limit:
+                description: Max allowed image size in bytes
+                example: 2097152
+                format: int64
+                type: integer
+                x-go-name: ImageSizeLimit
+            supported_mime_types:
+                description: List of mime types that it's possible to upload to this instance.
+                example:
+                    - image/jpeg
+                    - image/gif
+                items:
+                    type: string
+                type: array
+                x-go-name: SupportedMimeTypes
+            video_frame_rate_limit:
+                description: Max allowed video frame rate.
+                example: 60
+                format: int64
+                type: integer
+                x-go-name: VideoFrameRateLimit
+            video_matrix_limit:
+                description: |-
+                    Max allowed video size in pixels as height*width.
+
+                    GtS doesn't set a limit on this, but for compatibility
+                    we give Mastodon's 4096x4096px value here.
+                example: 16777216
+                format: int64
+                type: integer
+                x-go-name: VideoMatrixLimit
+            video_size_limit:
+                description: Max allowed video size in bytes
+                example: 10485760
+                format: int64
+                type: integer
+                x-go-name: VideoSizeLimit
+        title: InstanceConfigurationMediaAttachments models instance media attachment config parameters.
+        type: object
+        x-go-name: InstanceConfigurationMediaAttachments
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceConfigurationPolls:
+        properties:
+            max_characters_per_option:
+                description: Number of characters allowed per option in the poll.
+                example: 50
+                format: int64
+                type: integer
+                x-go-name: MaxCharactersPerOption
+            max_expiration:
+                description: Maximum expiration time of the poll in seconds.
+                example: 2629746
+                format: int64
+                type: integer
+                x-go-name: MaxExpiration
+            max_options:
+                description: Number of options permitted in a poll on this instance.
+                example: 4
+                format: int64
+                type: integer
+                x-go-name: MaxOptions
+            min_expiration:
+                description: Minimum expiration time of the poll in seconds.
+                example: 300
+                format: int64
+                type: integer
+                x-go-name: MinExpiration
+        title: InstanceConfigurationPolls models instance poll config parameters.
+        type: object
+        x-go-name: InstanceConfigurationPolls
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceConfigurationStatuses:
+        properties:
+            characters_reserved_per_url:
+                description: Amount of characters clients should assume a url takes up.
+                example: 25
+                format: int64
+                type: integer
+                x-go-name: CharactersReservedPerURL
+            max_characters:
+                description: Maximum allowed length of a post on this instance, in characters.
+                example: 5000
+                format: int64
+                type: integer
+                x-go-name: MaxCharacters
+            max_media_attachments:
+                description: Max number of attachments allowed on a status.
+                example: 4
+                format: int64
+                type: integer
+                x-go-name: MaxMediaAttachments
+        title: InstanceConfigurationStatuses models instance status config parameters.
+        type: object
+        x-go-name: InstanceConfigurationStatuses
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV1:
+        properties:
+            account_domain:
+                description: |-
+                    The domain of accounts on this instance.
+                    This will not necessarily be the same as
+                    simply the Host part of the URI.
+                example: example.org
+                type: string
+                x-go-name: AccountDomain
+            approval_required:
+                description: New account registrations require admin approval.
+                type: boolean
+                x-go-name: ApprovalRequired
+            configuration:
+                $ref: '#/definitions/instanceV1Configuration'
+            contact_account:
+                $ref: '#/definitions/account'
+            description:
+                description: |-
+                    Description of the instance.
+
+                    Should be HTML formatted, but might be plaintext.
+
+                    This should be displayed on the 'about' page for an instance.
+                type: string
+                x-go-name: Description
+            email:
+                description: An email address that may be used for inquiries.
+                example: admin@example.org
+                type: string
+                x-go-name: Email
+            invites_enabled:
+                description: Invites are enabled on this instance.
+                type: boolean
+                x-go-name: InvitesEnabled
+            languages:
+                description: Primary language of the instance.
+                example: en
+                items:
+                    type: string
+                type: array
+                x-go-name: Languages
+            max_toot_chars:
+                description: |-
+                    Maximum allowed length of a post on this instance, in characters.
+
+                    This is provided for compatibility with Tusky and other apps.
+                example: 5000
+                format: uint64
+                type: integer
+                x-go-name: MaxTootChars
+            registrations:
+                description: New account registrations are enabled on this instance.
+                type: boolean
+                x-go-name: Registrations
+            short_description:
+                description: |-
+                    A shorter description of the instance.
+
+                    Should be HTML formatted, but might be plaintext.
+
+                    This should be displayed on the instance splash/landing page.
+                type: string
+                x-go-name: ShortDescription
+            stats:
+                additionalProperties:
+                    format: int64
+                    type: integer
+                description: 'Statistics about the instance: number of posts, accounts, etc.'
+                type: object
+                x-go-name: Stats
+            thumbnail:
+                description: URL of the instance avatar/banner image.
+                example: https://example.org/files/instance/thumbnail.jpeg
+                type: string
+                x-go-name: Thumbnail
+            thumbnail_description:
+                description: Description of the instance thumbnail.
+                example: picture of a cute lil' friendly sloth
+                type: string
+                x-go-name: ThumbnailDescription
+            thumbnail_type:
+                description: MIME type of the instance thumbnail.
+                example: image/png
+                type: string
+                x-go-name: ThumbnailType
+            title:
+                description: The title of the instance.
+                example: GoToSocial Example Instance
+                type: string
+                x-go-name: Title
+            uri:
+                description: The URI of the instance.
+                example: https://gts.example.org
+                type: string
+                x-go-name: URI
+            urls:
+                $ref: '#/definitions/instanceV1URLs'
+            version:
+                description: |-
+                    The version of GoToSocial installed on the instance.
+
+                    This will contain at least a semantic version number.
+
+                    It may also contain, after a space, the short git commit ID of the running software.
+                example: 0.1.1 cb85f65
+                type: string
+                x-go-name: Version
+        title: InstanceV1 models information about this instance.
+        type: object
+        x-go-name: InstanceV1
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV1Configuration:
+        properties:
+            accounts:
+                $ref: '#/definitions/instanceConfigurationAccounts'
+            emojis:
+                $ref: '#/definitions/InstanceConfigurationEmojis'
+            media_attachments:
+                $ref: '#/definitions/instanceConfigurationMediaAttachments'
+            polls:
+                $ref: '#/definitions/instanceConfigurationPolls'
+            statuses:
+                $ref: '#/definitions/instanceConfigurationStatuses'
+        title: InstanceV1Configuration models instance configuration parameters.
+        type: object
+        x-go-name: InstanceV1Configuration
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV1URLs:
+        properties:
+            streaming_api:
+                description: Websockets address for status and notification streaming.
+                example: wss://example.org
+                type: string
+                x-go-name: StreamingAPI
+        title: InstanceV1URLs models instance-relevant URLs for client application consumption.
+        type: object
+        x-go-name: InstanceV1URLs
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2:
+        properties:
+            account_domain:
+                description: |-
+                    The domain of accounts on this instance.
+                    This will not necessarily be the same as
+                    domain.
+                example: example.org
+                type: string
+                x-go-name: AccountDomain
+            configuration:
+                $ref: '#/definitions/instanceV2Configuration'
+            contact:
+                $ref: '#/definitions/instanceV2Contact'
+            description:
+                description: |-
+                    Description of the instance.
+
+                    Should be HTML formatted, but might be plaintext.
+
+                    This should be displayed on the 'about' page for an instance.
+                type: string
+                x-go-name: Description
+            domain:
+                description: The domain of the instance.
+                example: gts.example.org
+                type: string
+                x-go-name: Domain
+            languages:
+                description: Primary languages of the instance + moderators/admins.
+                example:
+                    - en
+                items:
+                    type: string
+                type: array
+                x-go-name: Languages
+            registrations:
+                $ref: '#/definitions/instanceV2Registrations'
+            rules:
+                description: |-
+                    An itemized list of rules for this website.
+                    Currently not implemented (will always be empty array).
+                items: {}
+                type: array
+                x-go-name: Rules
+            source_url:
+                description: The URL for the source code of the software running on this instance, in keeping with AGPL license requirements.
+                example: https://github.com/superseriousbusiness/gotosocial
+                type: string
+                x-go-name: SourceURL
+            thumbnail:
+                $ref: '#/definitions/instanceV2Thumbnail'
+            title:
+                description: The title of the instance.
+                example: GoToSocial Example Instance
+                type: string
+                x-go-name: Title
+            usage:
+                $ref: '#/definitions/instanceV2Usage'
+            version:
+                description: |-
+                    The version of GoToSocial installed on the instance.
+
+                    This will contain at least a semantic version number.
+
+                    It may also contain, after a space, the short git commit ID of the running software.
+                example: 0.1.1 cb85f65
+                type: string
+                x-go-name: Version
+        title: InstanceV2 models information about this instance.
+        type: object
+        x-go-name: InstanceV2
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2Configuration:
+        properties:
+            accounts:
+                $ref: '#/definitions/instanceConfigurationAccounts'
+            emojis:
+                $ref: '#/definitions/InstanceConfigurationEmojis'
+            media_attachments:
+                $ref: '#/definitions/instanceConfigurationMediaAttachments'
+            polls:
+                $ref: '#/definitions/instanceConfigurationPolls'
+            statuses:
+                $ref: '#/definitions/instanceConfigurationStatuses'
+            translation:
+                $ref: '#/definitions/instanceV2ConfigurationTranslation'
+            urls:
+                $ref: '#/definitions/instanceV1URLs'
+        title: Configured values and limits for this instance.
+        type: object
+        x-go-name: InstanceV2Configuration
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2ConfigurationTranslation:
+        properties:
+            enabled:
+                description: |-
+                    Whether the Translations API is available on this instance.
+                    Not implemented so this value is always false.
+                type: boolean
+                x-go-name: Enabled
+        title: Hints related to translation.
+        type: object
+        x-go-name: InstanceV2ConfigurationTranslation
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2Contact:
+        properties:
+            account:
+                $ref: '#/definitions/account'
+            email:
+                description: |-
+                    An email address that can be messaged regarding inquiries or issues.
+                    Empty string if no email address set.
+                example: someone@example.org
+                type: string
+                x-go-name: Email
+        title: Hints related to contacting a representative of the instance.
+        type: object
+        x-go-name: InstanceV2Contact
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2Registrations:
+        properties:
+            approval_required:
+                description: Whether registrations require moderator approval.
+                example: true
+                type: boolean
+                x-go-name: ApprovalRequired
+            enabled:
+                description: Whether registrations are enabled.
+                example: false
+                type: boolean
+                x-go-name: Enabled
+            message:
+                description: |-
+                    A custom message (html string) to be shown when registrations are closed.
+                    Value will be null if no message is set.
+                example: <p>Registrations are currently closed on example.org because of spam bots!</p>
+                type: string
+                x-go-name: Message
+        title: Information about registering for this instance.
+        type: object
+        x-go-name: InstanceV2Registrations
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2Thumbnail:
+        properties:
+            blurhash:
+                description: |-
+                    A hash computed by the BlurHash algorithm, for generating colorful preview thumbnails when media has not been downloaded yet.
+                    Key/value not set if no blurhash available.
+                example: UeKUpFxuo~R%0nW;WCnhF6RjaJt757oJodS$
+                type: string
+                x-go-name: Blurhash
+            thumbnail_description:
+                description: |-
+                    Description of the instance thumbnail.
+                    Key/value not set if no description available.
+                example: picture of a cute lil' friendly sloth
+                type: string
+                x-go-name: Description
+            thumbnail_type:
+                description: |-
+                    MIME type of the instance thumbnail.
+                    Key/value not set if thumbnail image type unknown.
+                example: image/png
+                type: string
+                x-go-name: Type
+            url:
+                description: The URL for the thumbnail image.
+                example: https://example.org/fileserver/01BPSX2MKCRVMD4YN4D71G9CP5/attachment/original/01H88X0KQ2DFYYDSWYP93VDJZA.png
+                type: string
+                x-go-name: URL
+            versions:
+                $ref: '#/definitions/instanceV2ThumbnailVersions'
+        title: An image used to represent this instance.
+        type: object
+        x-go-name: InstanceV2Thumbnail
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2ThumbnailVersions:
+        properties:
+            '@1x':
+                description: |-
+                    The URL for the thumbnail image at 1x resolution.
+                    Key/value not set if scaled versions not available.
+                type: string
+                x-go-name: Size1URL
+            '@2x':
+                description: |-
+                    The URL for the thumbnail image at 2x resolution.
+                    Key/value not set if scaled versions not available.
+                type: string
+                x-go-name: Size2URL
+        title: Links to scaled resolution images, for high DPI screens.
+        type: object
+        x-go-name: InstanceV2ThumbnailVersions
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2Usage:
+        properties:
+            users:
+                $ref: '#/definitions/instanceV2Users'
+        title: Usage data for this instance.
+        type: object
+        x-go-name: InstanceV2Usage
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2Users:
+        properties:
+            active_month:
+                description: |-
+                    The number of active users in the past 4 weeks.
+                    Currently not implemented: will always be 0.
+                example: 0
+                format: int64
+                type: integer
+                x-go-name: ActiveMonth
+        title: Usage data related to users on this instance.
+        type: object
+        x-go-name: InstanceV2Users
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    mediaDimensions:
+        properties:
+            aspect:
+                description: |-
+                    Aspect ratio of the media.
+                    Equal to width / height.
+                example: 1.777777778
+                format: float
+                type: number
+                x-go-name: Aspect
+            bitrate:
+                description: Bitrate of the media in bits per second.
+                example: 1000000
+                format: int64
+                type: integer
+                x-go-name: Bitrate
+            duration:
+                description: |-
+                    Duration of the media in seconds.
+                    Only set for video and audio.
+                example: 5.43
+                format: float
+                type: number
+                x-go-name: Duration
+            frame_rate:
+                description: |-
+                    Framerate of the media.
+                    Only set for video and gifs.
+                example: "30"
+                type: string
+                x-go-name: FrameRate
+            height:
+                description: |-
+                    Height of the media in pixels.
+                    Not set for audio.
+                example: 1080
+                format: int64
+                type: integer
+                x-go-name: Height
+            size:
+                description: |-
+                    Size of the media, in the format `[width]x[height]`.
+                    Not set for audio.
+                example: 1920x1080
+                type: string
+                x-go-name: Size
+            width:
+                description: |-
+                    Width of the media in pixels.
+                    Not set for audio.
+                example: 1920
+                format: int64
+                type: integer
+                x-go-name: Width
+        title: MediaDimensions models detailed properties of a piece of media.
+        type: object
+        x-go-name: MediaDimensions
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    mediaFocus:
+        properties:
+            x:
+                description: |-
+                    x position of the focus
+                    should be between -1 and 1
+                format: float
+                type: number
+                x-go-name: X
+            "y":
+                description: |-
+                    y position of the focus
+                    should be between -1 and 1
+                format: float
+                type: number
+                x-go-name: "Y"
+        title: MediaFocus models the focal point of a piece of media.
+        type: object
+        x-go-name: MediaFocus
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    mediaMeta:
+        description: This can be metadata about an image, an audio file, video, etc.
+        properties:
+            focus:
+                $ref: '#/definitions/mediaFocus'
+            original:
+                $ref: '#/definitions/mediaDimensions'
+            small:
+                $ref: '#/definitions/mediaDimensions'
+        title: MediaMeta models media metadata.
+        type: object
+        x-go-name: MediaMeta
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    nodeinfo:
+        description: 'See: https://nodeinfo.diaspora.software/schema.html'
+        properties:
+            metadata:
+                additionalProperties: {}
+                description: Free form key value pairs for software specific values. Clients should not rely on any specific key present.
+                type: object
+                x-go-name: Metadata
+            openRegistrations:
+                description: Whether this server allows open self-registration.
+                example: false
+                type: boolean
+                x-go-name: OpenRegistrations
+            protocols:
+                description: The protocols supported on this server.
+                items:
+                    type: string
+                type: array
+                x-go-name: Protocols
+            services:
+                $ref: '#/definitions/NodeInfoServices'
+            software:
+                $ref: '#/definitions/NodeInfoSoftware'
+            usage:
+                $ref: '#/definitions/NodeInfoUsage'
+            version:
+                description: The schema version
+                example: "2.0"
+                type: string
+                x-go-name: Version
+        title: Nodeinfo represents a version 2.1 or version 2.0 nodeinfo schema.
+        type: object
+        x-go-name: Nodeinfo
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    notification:
+        properties:
+            account:
+                $ref: '#/definitions/account'
+            created_at:
+                description: The timestamp of the notification (ISO 8601 Datetime)
+                type: string
+                x-go-name: CreatedAt
+            id:
+                description: The id of the notification in the database.
+                type: string
+                x-go-name: ID
+            status:
+                $ref: '#/definitions/status'
+            type:
+                description: |-
+                    The type of event that resulted in the notification.
+                    follow = Someone followed you
+                    follow_request = Someone requested to follow you
+                    mention = Someone mentioned you in their status
+                    reblog = Someone boosted one of your statuses
+                    favourite = Someone favourited one of your statuses
+                    poll = A poll you have voted in or created has ended
+                    status = Someone you enabled notifications for has posted a status
+                type: string
+                x-go-name: Type
+        title: Notification represents a notification of an event relevant to the user.
+        type: object
+        x-go-name: Notification
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    oauthToken:
+        properties:
+            access_token:
+                description: Access token used for authorization.
+                type: string
+                x-go-name: AccessToken
+            created_at:
+                description: When the OAuth token was generated (UNIX timestamp seconds).
+                example: 1627644520
+                format: int64
+                type: integer
+                x-go-name: CreatedAt
+            scope:
+                description: OAuth scopes granted by this token, space-separated.
+                example: read write admin
+                type: string
+                x-go-name: Scope
+            token_type:
+                description: OAuth token type. Will always be 'Bearer'.
+                example: bearer
+                type: string
+                x-go-name: TokenType
+        title: Token represents an OAuth token used for authenticating with the GoToSocial API and performing actions.
+        type: object
+        x-go-name: Token
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    poll:
+        properties:
+            emojis:
+                description: Custom emoji to be used for rendering poll options.
+                items:
+                    $ref: '#/definitions/emoji'
+                type: array
+                x-go-name: Emojis
+            expired:
+                description: Is the poll currently expired?
+                type: boolean
+                x-go-name: Expired
+            expires_at:
+                description: When the poll ends. (ISO 8601 Datetime), or null if the poll does not end
+                type: string
+                x-go-name: ExpiresAt
+            id:
+                description: The ID of the poll in the database.
+                example: 01FBYKMD1KBMJ0W6JF1YZ3VY5D
+                type: string
+                x-go-name: ID
+            multiple:
+                description: Does the poll allow multiple-choice answers?
+                type: boolean
+                x-go-name: Multiple
+            options:
+                description: Possible answers for the poll.
+                items:
+                    $ref: '#/definitions/pollOptions'
+                type: array
+                x-go-name: Options
+            own_votes:
+                description: When called with a user token, which options has the authorized user chosen? Contains an array of index values for options.
+                items:
+                    format: int64
+                    type: integer
+                type: array
+                x-go-name: OwnVotes
+            voted:
+                description: When called with a user token, has the authorized user voted?
+                type: boolean
+                x-go-name: Voted
+            voters_count:
+                description: How many unique accounts have voted on a multiple-choice poll. Null if multiple is false.
+                format: int64
+                type: integer
+                x-go-name: VotersCount
+            votes_count:
+                description: How many votes have been received.
+                format: int64
+                type: integer
+                x-go-name: VotesCount
+        title: Poll represents a poll attached to a status.
+        type: object
+        x-go-name: Poll
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    pollOptions:
+        properties:
+            title:
+                description: The text value of the poll option. String.
+                type: string
+                x-go-name: Title
+            votes_count:
+                description: |-
+                    The number of received votes for this option.
+                    Number, or null if results are not published yet.
+                format: int64
+                type: integer
+                x-go-name: VotesCount
+        title: PollOptions represents the current vote counts for different poll options.
+        type: object
+        x-go-name: PollOptions
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    report:
+        properties:
+            action_taken:
+                description: Whether an action has been taken by an admin in response to this report.
+                example: false
+                type: boolean
+                x-go-name: ActionTaken
+            action_taken_at:
+                description: |-
+                    If an action was taken, at what time was this done? (ISO 8601 Datetime)
+                    Will be null if not set / no action yet taken.
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: ActionTakenAt
+            action_taken_comment:
+                description: |-
+                    If an action was taken, what comment was made by the admin on the taken action?
+                    Will be null if not set / no action yet taken.
+                example: Account was suspended.
+                type: string
+                x-go-name: ActionTakenComment
+            category:
+                description: Under what category was this report created?
+                example: spam
+                type: string
+                x-go-name: Category
+            comment:
+                description: |-
+                    Comment submitted when the report was created.
+                    Will be empty if no comment was submitted.
+                example: This person has been harassing me.
+                type: string
+                x-go-name: Comment
+            created_at:
+                description: The date when this report was created (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: CreatedAt
+            forwarded:
+                description: Bool to indicate that report should be federated to remote instance.
+                example: true
+                type: boolean
+                x-go-name: Forwarded
+            id:
+                description: ID of the report.
+                example: 01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: ID
+            rule_ids:
+                description: |-
+                    Array of rule IDs that were submitted along with this report.
+                    Will be empty if no rule IDs were submitted.
+                example:
+                    - 1
+                    - 2
+                items:
+                    format: int64
+                    type: integer
+                type: array
+                x-go-name: RuleIDs
+            status_ids:
+                description: |-
+                    Array of IDs of statuses that were submitted along with this report.
+                    Will be empty if no status IDs were submitted.
+                example:
+                    - 01GPBN5YDY6JKBWE44H7YQBDCQ
+                    - 01GPBN65PDWSBPWVDD0SQCFFY3
+                items:
+                    type: string
+                type: array
+                x-go-name: StatusIDs
+            target_account:
+                $ref: '#/definitions/account'
+        title: Report models a moderation report submitted to the instance, either via the client API or via the federated API.
+        type: object
+        x-go-name: Report
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    searchResult:
+        properties:
+            accounts:
+                items:
+                    $ref: '#/definitions/account'
+                type: array
+                x-go-name: Accounts
+            hashtags:
+                items:
+                    $ref: '#/definitions/tag'
+                type: array
+                x-go-name: Hashtags
+            statuses:
+                items:
+                    $ref: '#/definitions/status'
+                type: array
+                x-go-name: Statuses
+        title: SearchResult models a search result.
+        type: object
+        x-go-name: SearchResult
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    status:
+        properties:
+            account:
+                $ref: '#/definitions/account'
+            application:
+                $ref: '#/definitions/application'
+            bookmarked:
+                description: This status has been bookmarked by the account viewing it.
+                type: boolean
+                x-go-name: Bookmarked
+            card:
+                $ref: '#/definitions/card'
+            content:
+                description: The content of this status. Should be HTML, but might also be plaintext in some cases.
+                example: <p>Hey this is a status!</p>
+                type: string
+                x-go-name: Content
+            created_at:
+                description: The date when this status was created (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: CreatedAt
+            emojis:
+                description: Custom emoji to be used when rendering status content.
+                items:
+                    $ref: '#/definitions/emoji'
+                type: array
+                x-go-name: Emojis
+            favourited:
+                description: This status has been favourited by the account viewing it.
+                type: boolean
+                x-go-name: Favourited
+            favourites_count:
+                description: Number of favourites/likes this status has received, according to our instance.
+                format: int64
+                type: integer
+                x-go-name: FavouritesCount
+            id:
+                description: ID of the status.
+                example: 01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: ID
+            in_reply_to_account_id:
+                description: ID of the account being replied to.
+                example: 01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: InReplyToAccountID
+            in_reply_to_id:
+                description: ID of the status being replied to.
+                example: 01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: InReplyToID
+            language:
+                description: |-
+                    Primary language of this status (ISO 639 Part 1 two-letter language code).
+                    Will be null if language is not known.
+                example: en
+                type: string
+                x-go-name: Language
+            media_attachments:
+                description: Media that is attached to this status.
+                items:
+                    $ref: '#/definitions/attachment'
+                type: array
+                x-go-name: MediaAttachments
+            mentions:
+                description: Mentions of users within the status content.
+                items:
+                    $ref: '#/definitions/Mention'
+                type: array
+                x-go-name: Mentions
+            muted:
+                description: Replies to this status have been muted by the account viewing it.
+                type: boolean
+                x-go-name: Muted
+            pinned:
+                description: This status has been pinned by the account viewing it (only relevant for your own statuses).
+                type: boolean
+                x-go-name: Pinned
+            poll:
+                $ref: '#/definitions/poll'
+            reblog:
+                $ref: '#/definitions/statusReblogged'
+            reblogged:
+                description: This status has been boosted/reblogged by the account viewing it.
+                type: boolean
+                x-go-name: Reblogged
+            reblogs_count:
+                description: Number of times this status has been boosted/reblogged, according to our instance.
+                format: int64
+                type: integer
+                x-go-name: ReblogsCount
+            replies_count:
+                description: Number of replies to this status, according to our instance.
+                format: int64
+                type: integer
+                x-go-name: RepliesCount
+            sensitive:
+                description: Status contains sensitive content.
+                example: false
+                type: boolean
+                x-go-name: Sensitive
+            spoiler_text:
+                description: Subject, summary, or content warning for the status.
+                example: warning nsfw
+                type: string
+                x-go-name: SpoilerText
+            tags:
+                description: Hashtags used within the status content.
+                items:
+                    $ref: '#/definitions/tag'
+                type: array
+                x-go-name: Tags
+            text:
+                description: |-
+                    Plain-text source of a status. Returned instead of content when status is deleted,
+                    so the user may redraft from the source text without the client having to reverse-engineer
+                    the original text from the HTML content.
+                type: string
+                x-go-name: Text
+            uri:
+                description: ActivityPub URI of the status. Equivalent to the status's activitypub ID.
+                example: https://example.org/users/some_user/statuses/01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: URI
+            url:
+                description: The status's publicly available web URL. This link will only work if the visibility of the status is 'public'.
+                example: https://example.org/@some_user/statuses/01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: URL
+            visibility:
+                description: Visibility of this status.
+                example: unlisted
+                type: string
+                x-go-name: Visibility
+        title: Status models a status or post.
+        type: object
+        x-go-name: Status
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    statusContext:
+        properties:
+            ancestors:
+                description: Parents in the thread.
+                items:
+                    $ref: '#/definitions/status'
+                type: array
+                x-go-name: Ancestors
+            descendants:
+                description: Children in the thread.
+                items:
+                    $ref: '#/definitions/status'
+                type: array
+                x-go-name: Descendants
+        title: Context models the tree around a given status.
+        type: object
+        x-go-name: Context
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    statusCreateRequest:
+        properties:
+            format:
+                description: |-
+                    Format to use when parsing this status.
+                    in: formData
+                type: string
+                x-go-name: Format
+            in_reply_to_id:
+                description: |-
+                    ID of the status being replied to, if status is a reply.
+                    in: formData
+                type: string
+                x-go-name: InReplyToID
+            language:
+                description: |-
+                    ISO 639 language code for this status.
+                    in: formData
+                type: string
+                x-go-name: Language
+            media_ids:
+                description: |-
+                    Array of Attachment ids to be attached as media.
+                    If provided, status becomes optional, and poll cannot be used.
+
+                    If the status is being submitted as a form, the key is 'media_ids[]',
+                    but if it's json or xml, the key is 'media_ids'.
+
+                    in: formData
+                items:
+                    type: string
+                type: array
+                x-go-name: MediaIDs
+            scheduled_at:
+                description: |-
+                    ISO 8601 Datetime at which to schedule a status.
+                    Providing this parameter will cause ScheduledStatus to be returned instead of Status.
+                    Must be at least 5 minutes in the future.
+                    in: formData
+                type: string
+                x-go-name: ScheduledAt
+            sensitive:
+                description: |-
+                    Status and attached media should be marked as sensitive.
+                    in: formData
+                type: boolean
+                x-go-name: Sensitive
+            spoiler_text:
+                description: |-
+                    Text to be shown as a warning or subject before the actual content.
+                    Statuses are generally collapsed behind this field.
+                    in: formData
+                type: string
+                x-go-name: SpoilerText
+            status:
+                description: |-
+                    Text content of the status.
+                    If media_ids is provided, this becomes optional.
+                    Attaching a poll is optional while status is provided.
+                    in: formData
+                type: string
+                x-go-name: Status
+            visibility:
+                description: |-
+                    Visibility of the posted status.
+                    in: formData
+                type: string
+                x-go-name: Visibility
+        title: StatusCreateRequest models status creation parameters.
+        type: object
+        x-go-name: StatusCreateRequest
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    statusReblogged:
+        properties:
+            account:
+                $ref: '#/definitions/account'
+            application:
+                $ref: '#/definitions/application'
+            bookmarked:
+                description: This status has been bookmarked by the account viewing it.
+                type: boolean
+                x-go-name: Bookmarked
+            card:
+                $ref: '#/definitions/card'
+            content:
+                description: The content of this status. Should be HTML, but might also be plaintext in some cases.
+                example: <p>Hey this is a status!</p>
+                type: string
+                x-go-name: Content
+            created_at:
+                description: The date when this status was created (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: CreatedAt
+            emojis:
+                description: Custom emoji to be used when rendering status content.
+                items:
+                    $ref: '#/definitions/emoji'
+                type: array
+                x-go-name: Emojis
+            favourited:
+                description: This status has been favourited by the account viewing it.
+                type: boolean
+                x-go-name: Favourited
+            favourites_count:
+                description: Number of favourites/likes this status has received, according to our instance.
+                format: int64
+                type: integer
+                x-go-name: FavouritesCount
+            id:
+                description: ID of the status.
+                example: 01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: ID
+            in_reply_to_account_id:
+                description: ID of the account being replied to.
+                example: 01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: InReplyToAccountID
+            in_reply_to_id:
+                description: ID of the status being replied to.
+                example: 01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: InReplyToID
+            language:
+                description: |-
+                    Primary language of this status (ISO 639 Part 1 two-letter language code).
+                    Will be null if language is not known.
+                example: en
+                type: string
+                x-go-name: Language
+            media_attachments:
+                description: Media that is attached to this status.
+                items:
+                    $ref: '#/definitions/attachment'
+                type: array
+                x-go-name: MediaAttachments
+            mentions:
+                description: Mentions of users within the status content.
+                items:
+                    $ref: '#/definitions/Mention'
+                type: array
+                x-go-name: Mentions
+            muted:
+                description: Replies to this status have been muted by the account viewing it.
+                type: boolean
+                x-go-name: Muted
+            pinned:
+                description: This status has been pinned by the account viewing it (only relevant for your own statuses).
+                type: boolean
+                x-go-name: Pinned
+            poll:
+                $ref: '#/definitions/poll'
+            reblog:
+                $ref: '#/definitions/statusReblogged'
+            reblogged:
+                description: This status has been boosted/reblogged by the account viewing it.
+                type: boolean
+                x-go-name: Reblogged
+            reblogs_count:
+                description: Number of times this status has been boosted/reblogged, according to our instance.
+                format: int64
+                type: integer
+                x-go-name: ReblogsCount
+            replies_count:
+                description: Number of replies to this status, according to our instance.
+                format: int64
+                type: integer
+                x-go-name: RepliesCount
+            sensitive:
+                description: Status contains sensitive content.
+                example: false
+                type: boolean
+                x-go-name: Sensitive
+            spoiler_text:
+                description: Subject, summary, or content warning for the status.
+                example: warning nsfw
+                type: string
+                x-go-name: SpoilerText
+            tags:
+                description: Hashtags used within the status content.
+                items:
+                    $ref: '#/definitions/tag'
+                type: array
+                x-go-name: Tags
+            text:
+                description: |-
+                    Plain-text source of a status. Returned instead of content when status is deleted,
+                    so the user may redraft from the source text without the client having to reverse-engineer
+                    the original text from the HTML content.
+                type: string
+                x-go-name: Text
+            uri:
+                description: ActivityPub URI of the status. Equivalent to the status's activitypub ID.
+                example: https://example.org/users/some_user/statuses/01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: URI
+            url:
+                description: The status's publicly available web URL. This link will only work if the visibility of the status is 'public'.
+                example: https://example.org/@some_user/statuses/01FBVD42CQ3ZEEVMW180SBX03B
+                type: string
+                x-go-name: URL
+            visibility:
+                description: Visibility of this status.
+                example: unlisted
+                type: string
+                x-go-name: Visibility
+        title: StatusReblogged represents a reblogged status.
+        type: object
+        x-go-name: StatusReblogged
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    swaggerCollection:
+        properties:
+            '@context':
+                description: ActivityStreams context.
+                example: https://www.w3.org/ns/activitystreams
+                type: string
+                x-go-name: Context
+            first:
+                $ref: '#/definitions/swaggerCollectionPage'
+            id:
+                description: ActivityStreams ID.
+                example: https://example.org/users/some_user/statuses/106717595988259568/replies
+                type: string
+                x-go-name: ID
+            last:
+                $ref: '#/definitions/swaggerCollectionPage'
+            type:
+                description: ActivityStreams type.
+                example: Collection
+                type: string
+                x-go-name: Type
+        title: SwaggerCollection represents an activitypub collection.
+        type: object
+        x-go-name: SwaggerCollection
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/activitypub/users
+    swaggerCollectionPage:
+        properties:
+            id:
+                description: ActivityStreams ID.
+                example: https://example.org/users/some_user/statuses/106717595988259568/replies?page=true
+                type: string
+                x-go-name: ID
+            items:
+                description: Items on this page.
+                example:
+                    - https://example.org/users/some_other_user/statuses/086417595981111564
+                    - https://another.example.com/users/another_user/statuses/01FCN8XDV3YG7B4R42QA6YQZ9R
+                items:
+                    type: string
+                type: array
+                x-go-name: Items
+            next:
+                description: Link to the next page.
+                example: https://example.org/users/some_user/statuses/106717595988259568/replies?only_other_accounts=true&page=true
+                type: string
+                x-go-name: Next
+            partOf:
+                description: Collection this page belongs to.
+                example: https://example.org/users/some_user/statuses/106717595988259568/replies
+                type: string
+                x-go-name: PartOf
+            type:
+                description: ActivityStreams type.
+                example: CollectionPage
+                type: string
+                x-go-name: Type
+        title: SwaggerCollectionPage represents one page of a collection.
+        type: object
+        x-go-name: SwaggerCollectionPage
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/activitypub/users
+    tag:
+        properties:
+            name:
+                description: 'The value of the hashtag after the # sign.'
+                example: helloworld
+                type: string
+                x-go-name: Name
+            url:
+                description: Web link to the hashtag.
+                example: https://example.org/tags/helloworld
+                type: string
+                x-go-name: URL
+        title: Tag represents a hashtag used within the content of a status.
+        type: object
+        x-go-name: Tag
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    updateField:
+        description: By default, max 4 fields and 255 characters per property/value.
+        properties:
+            name:
+                description: Name of the field
+                type: string
+                x-go-name: Name
+            value:
+                description: Value of the field
+                type: string
+                x-go-name: Value
+        title: UpdateField is to be used specifically in an UpdateCredentialsRequest.
+        type: object
+        x-go-name: UpdateField
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    updateSource:
+        properties:
+            language:
+                description: Default language to use for authored statuses. (ISO 6391)
+                type: string
+                x-go-name: Language
+            privacy:
+                description: Default post privacy for authored statuses.
+                type: string
+                x-go-name: Privacy
+            sensitive:
+                description: Mark authored statuses as sensitive by default.
+                type: boolean
+                x-go-name: Sensitive
+            status_format:
+                description: Default format for authored statuses (plain or markdown).
+                type: string
+                x-go-name: StatusFormat
+        title: UpdateSource is to be used specifically in an UpdateCredentialsRequest.
+        type: object
+        x-go-name: UpdateSource
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    wellKnownResponse:
+        description: See https://webfinger.net/
+        properties:
+            aliases:
+                items:
+                    type: string
+                type: array
+                x-go-name: Aliases
+            links:
+                items:
+                    $ref: '#/definitions/Link'
+                type: array
+                x-go-name: Links
+            subject:
+                type: string
+                x-go-name: Subject
+        title: |-
+            WellKnownResponse represents the response to either a webfinger request for an 'acct' resource, or a request to nodeinfo.
+            For example, it would be returned from https://example.org/.well-known/webfinger?resource=acct:some_username@example.org
+        type: object
+        x-go-name: WellKnownResponse
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+host: example.org
+info:
+    contact:
+        email: admin@gotosocial.org
+        name: GoToSocial Authors
+    license:
+        name: AGPL3
+        url: https://www.gnu.org/licenses/agpl-3.0.en.html
+    title: GoToSocial Swagger documentation.
+    version: REPLACE_ME
+paths:
+    /.well-known/nodeinfo:
+        get:
+            description: |-
+                eg. `{"links":[{"rel":"http://nodeinfo.diaspora.software/ns/schema/2.0","href":"http://example.org/nodeinfo/2.0"}]}`
+                See: https://nodeinfo.diaspora.software/protocol.html
+            operationId: nodeInfoWellKnownGet
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    schema:
+                        $ref: '#/definitions/wellKnownResponse'
+            summary: Returns a well-known response which redirects callers to `/nodeinfo/2.0`.
+            tags:
+                - .well-known
+    /.well-known/webfinger:
+        get:
+            description: |-
+                For example, a GET to `https://goblin.technology/.well-known/webfinger?resource=acct:tobi@goblin.technology` would return:
+
+                ```
+
+                {"subject":"acct:tobi@goblin.technology","aliases":["https://goblin.technology/users/tobi","https://goblin.technology/@tobi"],"links":[{"rel":"http://webfinger.net/rel/profile-page","type":"text/html","href":"https://goblin.technology/@tobi"},{"rel":"self","type":"application/activity+json","href":"https://goblin.technology/users/tobi"}]}
+
+                ```
+
+                See: https://webfinger.net/
+            operationId: webfingerGet
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    schema:
+                        $ref: '#/definitions/wellKnownResponse'
+            summary: Handles webfinger account lookup requests.
+            tags:
+                - .well-known
+    /api/{api_version}/media:
+        post:
+            consumes:
+                - multipart/form-data
+            operationId: mediaCreate
+            parameters:
+                - description: Version of the API to use. Must be either `v1` or `v2`.
+                  in: path
+                  name: api_version
+                  required: true
+                  type: string
+                - description: Image or media description to use as alt-text on the attachment. This is very useful for users of screenreaders! May or may not be required, depending on your instance settings.
+                  in: formData
+                  name: description
+                  type: string
+                - default: 0,0
+                  description: 'Focus of the media file. If present, it should be in the form of two comma-separated floats between -1 and 1. For example: `-0.5,0.25`.'
+                  in: formData
+                  name: focus
+                  type: string
+                - description: The media attachment to upload.
+                  in: formData
+                  name: file
+                  required: true
+                  type: file
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The newly-created media attachment.
+                    schema:
+                        $ref: '#/definitions/attachment'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "422":
+                    description: unprocessable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:media
+            summary: Upload a new media attachment.
+            tags:
+                - media
+    /api/v1/accounts:
+        post:
+            consumes:
+                - application/json
+                - application/xml
+                - application/x-www-form-urlencoded
+            description: |-
+                The parameters can also be given in the body of the request, as JSON, if the content-type is set to 'application/json'.
+                The parameters can also be given in the body of the request, as XML, if the content-type is set to 'application/xml'.
+            operationId: accountCreate
+            parameters:
+                - description: Text that will be reviewed by moderators if registrations require manual approval.
+                  in: query
+                  name: reason
+                  type: string
+                  x-go-name: Reason
+                - description: The desired username for the account.
+                  in: query
+                  name: username
+                  type: string
+                  x-go-name: Username
+                - description: The email address to be used for login.
+                  in: query
+                  name: email
+                  type: string
+                  x-go-name: Email
+                - description: The password to be used for login. This will be hashed before storage.
+                  in: query
+                  name: password
+                  type: string
+                  x-go-name: Password
+                - description: The user agrees to the terms, conditions, and policies of the instance.
+                  in: query
+                  name: agreement
+                  type: boolean
+                  x-go-name: Agreement
+                - description: The language of the confirmation email that will be sent.
+                  in: query
+                  name: locale
+                  type: string
+                  x-go-name: Locale
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: An OAuth2 access token for the newly-created account.
+                    schema:
+                        $ref: '#/definitions/oauthToken'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Application:
+                    - write:accounts
+            summary: Create a new account using an application token.
+            tags:
+                - accounts
+    /api/v1/accounts/{id}:
+        get:
+            operationId: accountGet
+            parameters:
+                - description: The id of the requested account.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The requested account.
+                    schema:
+                        $ref: '#/definitions/account'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:accounts
+            summary: Get information about an account with the given ID.
+            tags:
+                - accounts
+    /api/v1/accounts/{id}/block:
+        post:
+            operationId: accountBlock
+            parameters:
+                - description: The id of the account to block.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Your relationship to the account.
+                    schema:
+                        $ref: '#/definitions/accountRelationship'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:blocks
+            summary: Block account with id.
+            tags:
+                - accounts
+    /api/v1/accounts/{id}/follow:
+        post:
+            consumes:
+                - application/json
+                - application/xml
+                - application/x-www-form-urlencoded
+            description: |-
+                The parameters can also be given in the body of the request, as JSON, if the content-type is set to 'application/json'.
+                The parameters can also be given in the body of the request, as XML, if the content-type is set to 'application/xml'.
+            operationId: accountFollow
+            parameters:
+                - description: ID of the account to follow.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+                - default: true
+                  description: Show reblogs from this account.
+                  in: formData
+                  name: reblogs
+                  type: boolean
+                - default: false
+                  description: Notify when this account posts.
+                  in: formData
+                  name: notify
+                  type: boolean
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Your relationship to this account.
+                    schema:
+                        $ref: '#/definitions/accountRelationship'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:follows
+            summary: Follow account with id.
+            tags:
+                - accounts
+    /api/v1/accounts/{id}/followers:
+        get:
+            operationId: accountFollowers
+            parameters:
+                - description: Account ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of accounts that follow this account.
+                    schema:
+                        items:
+                            $ref: '#/definitions/account'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:accounts
+            summary: See followers of account with given id.
+            tags:
+                - accounts
+    /api/v1/accounts/{id}/following:
+        get:
+            operationId: accountFollowing
+            parameters:
+                - description: Account ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of accounts that are followed by this account.
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:accounts
+            summary: See accounts followed by given account id.
+            tags:
+                - accounts
+    /api/v1/accounts/{id}/statuses:
+        get:
+            description: The statuses will be returned in descending chronological order (newest first), with sequential IDs (bigger = newer).
+            operationId: accountStatuses
+            parameters:
+                - description: Account ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+                - default: 30
+                  description: Number of statuses to return.
+                  in: query
+                  name: limit
+                  type: integer
+                - default: false
+                  description: Exclude statuses that are a reply to another status.
+                  in: query
+                  name: exclude_replies
+                  type: boolean
+                - default: false
+                  description: Exclude statuses that are a reblog/boost of another status.
+                  in: query
+                  name: exclude_reblogs
+                  type: boolean
+                - description: Return only statuses *OLDER* than the given max status ID. The status with the specified ID will not be included in the response.
+                  in: query
+                  name: max_id
+                  type: string
+                - description: Return only statuses *NEWER* than the given min status ID. The status with the specified ID will not be included in the response.
+                  in: query
+                  name: min_id
+                  type: string
+                - default: false
+                  description: Show only pinned statuses. In other words, exclude statuses that are not pinned to the given account ID.
+                  in: query
+                  name: pinned_only
+                  type: boolean
+                - default: false
+                  description: Show only statuses with media attachments.
+                  in: query
+                  name: only_media
+                  type: boolean
+                - default: false
+                  description: Show only statuses with a privacy setting of 'public'.
+                  in: query
+                  name: only_public
+                  type: boolean
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of statuses.
+                    schema:
+                        items:
+                            $ref: '#/definitions/status'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:accounts
+            summary: See statuses posted by the requested account.
+            tags:
+                - accounts
+    /api/v1/accounts/{id}/unblock:
+        post:
+            operationId: accountUnblock
+            parameters:
+                - description: The id of the account to unblock.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Your relationship to this account.
+                    schema:
+                        $ref: '#/definitions/accountRelationship'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:blocks
+            summary: Unblock account with ID.
+            tags:
+                - accounts
+    /api/v1/accounts/{id}/unfollow:
+        post:
+            operationId: accountUnfollow
+            parameters:
+                - description: The id of the account to unfollow.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Your relationship to this account.
+                    schema:
+                        $ref: '#/definitions/accountRelationship'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:follows
+            summary: Unfollow account with id.
+            tags:
+                - accounts
+    /api/v1/accounts/delete:
+        post:
+            consumes:
+                - multipart/form-data
+            operationId: accountDelete
+            parameters:
+                - description: Password of the account user, for confirmation.
+                  in: formData
+                  name: password
+                  required: true
+                  type: string
+            responses:
+                "202":
+                    description: The account deletion has been accepted and the account will be deleted.
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:accounts
+            summary: Delete your account.
+            tags:
+                - accounts
+    /api/v1/accounts/relationships:
+        get:
+            operationId: accountRelationships
+            parameters:
+                - description: Account IDs.
+                  in: query
+                  items:
+                    type: string
+                  name: id
+                  required: true
+                  type: array
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of account relationships.
+                    schema:
+                        items:
+                            $ref: '#/definitions/accountRelationship'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:accounts
+            summary: See your account's relationships with the given account IDs.
+            tags:
+                - accounts
+    /api/v1/accounts/update_credentials:
+        patch:
+            consumes:
+                - multipart/form-data
+            operationId: accountUpdate
+            parameters:
+                - description: Account should be made discoverable and shown in the profile directory (if enabled).
+                  in: formData
+                  name: discoverable
+                  type: boolean
+                - description: Account is flagged as a bot.
+                  in: formData
+                  name: bot
+                  type: boolean
+                - allowEmptyValue: true
+                  description: The display name to use for the account.
+                  in: formData
+                  name: display_name
+                  type: string
+                - allowEmptyValue: true
+                  description: Bio/description of this account.
+                  in: formData
+                  name: note
+                  type: string
+                - description: Avatar of the user.
+                  in: formData
+                  name: avatar
+                  type: file
+                - description: Header of the user.
+                  in: formData
+                  name: header
+                  type: file
+                - description: Require manual approval of follow requests.
+                  in: formData
+                  name: locked
+                  type: boolean
+                - description: Default post privacy for authored statuses.
+                  in: formData
+                  name: source[privacy]
+                  type: string
+                - description: Mark authored statuses as sensitive by default.
+                  in: formData
+                  name: source[sensitive]
+                  type: boolean
+                - description: Default language to use for authored statuses (ISO 6391).
+                  in: formData
+                  name: source[language]
+                  type: string
+                - description: Default format to use for authored statuses (plain or markdown).
+                  in: formData
+                  name: source[status_format]
+                  type: string
+                - description: Custom CSS to use when rendering this account's profile or statuses. String must be no more than 5,000 characters (~5kb).
+                  in: formData
+                  name: custom_css
+                  type: string
+                - description: Enable RSS feed for this account's Public posts at `/[username]/feed.rss`
+                  in: formData
+                  name: enable_rss
+                  type: boolean
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The newly updated account.
+                    schema:
+                        $ref: '#/definitions/account'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:accounts
+            summary: Update your account.
+            tags:
+                - accounts
+    /api/v1/accounts/verify_credentials:
+        get:
+            operationId: accountVerify
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    schema:
+                        $ref: '#/definitions/account'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:accounts
+            summary: Verify a token by returning account details pertaining to it.
+            tags:
+                - accounts
+    /api/v1/admin/accounts/{id}/action:
+        post:
+            consumes:
+                - multipart/form-data
+            operationId: adminAccountAction
+            parameters:
+                - description: ID of the account.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+                - description: Type of action to be taken (`disable`, `silence`, or `suspend`).
+                  in: formData
+                  name: type
+                  required: true
+                  type: string
+                - description: Optional text describing why this action was taken.
+                  in: formData
+                  name: text
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: OK
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: Perform an admin action on an account.
+            tags:
+                - admin
+    /api/v1/admin/custom_emojis:
+        get:
+            description: |-
+                The next and previous queries can be parsed from the returned Link header.
+                Example:
+
+                `<http://localhost:8080/api/v1/admin/custom_emojis?limit=30&max_shortcode_domain=yell@fossbros-anonymous.io&filter=domain:all>; rel="next", <http://localhost:8080/api/v1/admin/custom_emojis?limit=30&min_shortcode_domain=rainbow@&filter=domain:all>; rel="prev"`
+            operationId: emojisGet
+            parameters:
+                - default: domain:all
+                  description: |-
+                    Comma-separated list of filters to apply to results. Recognized filters are:
+
+                    `domain:[domain]` -- show emojis from the given domain, eg `?filter=domain:example.org` will show emojis from `example.org` only.
+                    Instead of giving a specific domain, you can also give either one of the key words `local` or `all` to show either local emojis only (`domain:local`) or show all emojis from all domains (`domain:all`).
+                    Note: `domain:*` is equivalent to `domain:all` (including local).
+                    If no domain filter is provided, `domain:all` will be assumed.
+
+                    `disabled` -- include emojis that have been disabled.
+
+                    `enabled` -- include emojis that are enabled.
+
+                    `shortcode:[shortcode]` -- show only emojis with the given shortcode, eg `?filter=shortcode:blob_cat_uwu` will show only emojis with the shortcode `blob_cat_uwu` (case sensitive).
+
+                    If neither `disabled` or `enabled` are provided, both disabled and enabled emojis will be shown.
+
+                    If no filter query string is provided, the default `domain:all` will be used, which will show all emojis from all domains.
+                  in: query
+                  name: filter
+                  type: string
+                - default: 50
+                  description: Number of emojis to return. Less than 1, or not set, means unlimited (all emojis).
+                  in: query
+                  name: limit
+                  type: integer
+                - description: |-
+                    Return only emojis with `[shortcode]@[domain]` *LOWER* (alphabetically) than given `[shortcode]@[domain]`. For example, if `max_shortcode_domain=beep@example.org`, then returned values might include emojis with `[shortcode]@[domain]`s like `car@example.org`, `debian@aaa.com`, `test@` (local emoji), etc.
+                    Emoji with the given `[shortcode]@[domain]` will not be included in the result set.
+                  in: query
+                  name: max_shortcode_domain
+                  type: string
+                - description: |-
+                    Return only emojis with `[shortcode]@[domain]` *HIGHER* (alphabetically) than given `[shortcode]@[domain]`. For example, if `max_shortcode_domain=beep@example.org`, then returned values might include emojis with `[shortcode]@[domain]`s like `arse@test.com`, `0101_binary@hackers.net`, `bee@` (local emoji), etc.
+                    Emoji with the given `[shortcode]@[domain]` will not be included in the result set.
+                  in: query
+                  name: min_shortcode_domain
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: An array of emojis, arranged alphabetically by shortcode and domain.
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
+                    schema:
+                        items:
+                            $ref: '#/definitions/adminEmoji'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            summary: View local and remote emojis available to / known by this instance.
+            tags:
+                - admin
+        post:
+            consumes:
+                - multipart/form-data
+            operationId: emojiCreate
+            parameters:
+                - description: The code to use for the emoji, which will be used by instance denizens to select it. This must be unique on the instance.
+                  in: formData
+                  name: shortcode
+                  pattern: \w{2,30}
+                  required: true
+                  type: string
+                - description: A png or gif image of the emoji. Animated pngs work too! To ensure compatibility with other fedi implementations, emoji size limit is 50kb by default.
+                  in: formData
+                  name: image
+                  required: true
+                  type: file
+                - description: Category in which to place the new emoji. 64 characters or less. If left blank, emoji will be uncategorized. If a category with the given name doesn't exist yet, it will be created.
+                  in: formData
+                  name: category
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The newly-created emoji.
+                    schema:
+                        $ref: '#/definitions/emoji'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "409":
+                    description: conflict -- shortcode for this emoji is already in use
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: Upload and create a new instance emoji.
+            tags:
+                - admin
+    /api/v1/admin/custom_emojis/{id}:
+        delete:
+            description: |-
+                Emoji with the given ID will no longer be available to use on the instance.
+
+                If you just want to update the emoji image instead, use the `/api/v1/admin/custom_emojis/{id}` PATCH route.
+
+                To disable emojis from **remote** instances, use the `/api/v1/admin/custom_emojis/{id}` PATCH route.
+            operationId: emojiDelete
+            parameters:
+                - description: The id of the emoji.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The deleted emoji will be returned to the caller in case further processing is necessary.
+                    schema:
+                        $ref: '#/definitions/adminEmoji'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: Delete a **local** emoji with the given ID from the instance.
+            tags:
+                - admin
+        get:
+            operationId: emojiGet
+            parameters:
+                - description: The id of the emoji.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: A single emoji.
+                    schema:
+                        $ref: '#/definitions/adminEmoji'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            summary: Get the admin view of a single emoji.
+            tags:
+                - admin
+        patch:
+            consumes:
+                - multipart/form-data
+            description: |-
+                Action performed depends upon the action `type` provided.
+
+                `disable`: disable a REMOTE emoji from being used/displayed on this instance. Does not work for local emojis.
+
+                `copy`: copy a REMOTE emoji to this instance. When doing this action, a shortcode MUST be provided, and it must
+                be unique among emojis already present on this instance. A category MAY be provided, and the copied emoji will then
+                be put into the provided category.
+
+                `modify`: modify a LOCAL emoji. You can provide a new image for the emoji and/or update the category.
+
+                Local emojis cannot be deleted using this endpoint. To delete a local emoji, check DELETE /api/v1/admin/custom_emojis/{id} instead.
+            operationId: emojiUpdate
+            parameters:
+                - description: The id of the emoji.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+                - description: |-
+                    Type of action to be taken. One of: (`disable`, `copy`, `modify`).
+                    For REMOTE emojis, `copy` or `disable` are supported.
+                    For LOCAL emojis, only `modify` is supported.
+                  in: formData
+                  name: type
+                  required: true
+                  type: string
+                - description: The code to use for the emoji, which will be used by instance denizens to select it. This must be unique on the instance. Works for the `copy` action type only.
+                  in: formData
+                  name: shortcode
+                  pattern: \w{2,30}
+                  type: string
+                - description: A new png or gif image to use for the emoji. Animated pngs work too! To ensure compatibility with other fedi implementations, emoji size limit is 50kb by default. Works for LOCAL emojis only.
+                  in: formData
+                  name: image
+                  type: file
+                - description: Category in which to place the emoji. 64 characters or less. If a category with the given name doesn't exist yet, it will be created.
+                  in: formData
+                  name: category
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The updated emoji.
+                    schema:
+                        $ref: '#/definitions/adminEmoji'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: Perform admin action on a local or remote emoji known to this instance.
+            tags:
+                - admin
+    /api/v1/admin/custom_emojis/{id}/categories:
+        get:
+            operationId: emojiCategoriesGet
+            parameters:
+                - description: The id of the emoji.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of existing emoji categories.
+                    schema:
+                        items:
+                            $ref: '#/definitions/adminEmojiCategory'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            summary: Get a list of existing emoji categories.
+            tags:
+                - admin
+    /api/v1/admin/domain_blocks:
+        get:
+            operationId: domainBlocksGet
+            parameters:
+                - description: If set to `true`, then each entry in the returned list of domain blocks will only consist of the fields `domain` and `public_comment`. This is perfect for when you want to save and share a list of all the domains you have blocked on your instance, so that someone else can easily import them, but you don't want them to see the database IDs of your blocks, or private comments etc.
+                  in: query
+                  name: export
+                  type: boolean
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: All domain blocks currently in place.
+                    schema:
+                        items:
+                            $ref: '#/definitions/domainBlock'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: View all domain blocks currently in place.
+            tags:
+                - admin
+        post:
+            consumes:
+                - multipart/form-data
+            description: |-
+                You have two options when using this endpoint: either you can set `import` to `true` and
+                upload a file containing multiple domain blocks, JSON-formatted, or you can leave import as
+                `false`, and just add one domain block.
+
+                The format of the json file should be something like: `[{"domain":"example.org"},{"domain":"whatever.com","public_comment":"they smell"}]`
+            operationId: domainBlockCreate
+            parameters:
+                - default: false
+                  description: Signal that a list of domain blocks is being imported as a file. If set to `true`, then 'domains' must be present as a JSON-formatted file. If set to `false`, then `domains` will be ignored, and `domain` must be present.
+                  in: query
+                  name: import
+                  type: boolean
+                - description: JSON-formatted list of domain blocks to import. This is only used if `import` is set to `true`.
+                  in: formData
+                  name: domains
+                  type: file
+                - description: Single domain to block. Used only if `import` is not `true`.
+                  in: formData
+                  name: domain
+                  type: string
+                - description: Obfuscate the name of the domain when serving it publicly. Eg., `example.org` becomes something like `ex***e.org`. Used only if `import` is not `true`.
+                  in: formData
+                  name: obfuscate
+                  type: boolean
+                - description: Public comment about this domain block. This will be displayed alongside the domain block if you choose to share blocks. Used only if `import` is not `true`.
+                  in: formData
+                  name: public_comment
+                  type: string
+                - description: Private comment about this domain block. Will only be shown to other admins, so this is a useful way of internally keeping track of why a certain domain ended up blocked. Used only if `import` is not `true`.
+                  in: formData
+                  name: private_comment
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The newly created domain block, if `import` != `true`. If a list has been imported, then an `array` of newly created domain blocks will be returned instead.
+                    schema:
+                        $ref: '#/definitions/domainBlock'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: Create one or more domain blocks, from a string or a file.
+            tags:
+                - admin
+    /api/v1/admin/domain_blocks/{id}:
+        delete:
+            operationId: domainBlockDelete
+            parameters:
+                - description: The id of the domain block.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The domain block that was just deleted.
+                    schema:
+                        $ref: '#/definitions/domainBlock'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: Delete domain block with the given ID.
+            tags:
+                - admin
+        get:
+            operationId: domainBlockGet
+            parameters:
+                - description: The id of the domain block.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The requested domain block.
+                    schema:
+                        $ref: '#/definitions/domainBlock'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: View domain block with the given ID.
+            tags:
+                - admin
+    /api/v1/admin/media_cleanup:
+        post:
+            consumes:
+                - application/json
+                - application/xml
+                - application/x-www-form-urlencoded
+            description: Also cleans up unused headers + avatars from the media cache and prunes orphaned items from storage.
+            operationId: mediaCleanup
+            parameters:
+                - description: |-
+                    Number of days of remote media to keep. Native values will be treated as 0.
+                    If value is not specified, the value of media-remote-cache-days in the server config will be used.
+                  format: int64
+                  in: query
+                  name: remote_cache_days
+                  type: integer
+                  x-go-name: RemoteCacheDays
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Echos the number of days requested. The cleanup is performed asynchronously after the request completes.
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: Clean up remote media older than the specified number of days.
+            tags:
+                - admin
+    /api/v1/admin/media_refetch:
+        post:
+            description: |-
+                Currently, this only includes remote emojis.
+                This endpoint is useful when data loss has occurred, and you want to try to recover to a working state.
+            operationId: mediaRefetch
+            parameters:
+                - description: Domain to refetch media from. If empty, all domains will be refetched.
+                  in: query
+                  name: domain
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "202":
+                    description: Request accepted and will be processed. Check the logs for progress / errors.
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: Refetch media specified in the database but missing from storage.
+            tags:
+                - admin
+    /api/v1/admin/reports:
+        get:
+            description: |-
+                The reports will be returned in descending chronological order (newest first), with sequential IDs (bigger = newer).
+
+                The next and previous queries can be parsed from the returned Link header.
+
+                Example:
+
+                ```
+                <https://example.org/api/v1/admin/reports?limit=20&max_id=01FC0SKA48HNSVR6YKZCQGS2V8>; rel="next", <https://example.org/api/v1/admin/reports?limit=20&min_id=01FC0SKW5JK2Q4EVAV2B462YY0>; rel="prev"
+                ````
+            operationId: adminReports
+            parameters:
+                - description: If set to true, only resolved reports will be returned. If false, only unresolved reports will be returned. If unset, reports will not be filtered on their resolved status.
+                  in: query
+                  name: resolved
+                  type: boolean
+                - description: Return only reports created by the given account id.
+                  in: query
+                  name: account_id
+                  type: string
+                - description: Return only reports that target the given account id.
+                  in: query
+                  name: target_account_id
+                  type: string
+                - description: Return only reports *OLDER* than the given max ID. The report with the specified ID will not be included in the response.
+                  in: query
+                  name: max_id
+                  type: string
+                - description: Return only reports *NEWER* than the given since ID. The report with the specified ID will not be included in the response. This parameter is functionally equivalent to min_id.
+                  in: query
+                  name: since_id
+                  type: string
+                - description: Return only reports *NEWER* than the given min ID. The report with the specified ID will not be included in the response. This parameter is functionally equivalent to since_id.
+                  in: query
+                  name: min_id
+                  type: string
+                - default: 20
+                  description: Number of reports to return. If less than 1, will be clamped to 1. If more than 100, will be clamped to 100.
+                  in: query
+                  name: limit
+                  type: integer
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of reports.
+                    schema:
+                        items:
+                            $ref: '#/definitions/adminReport'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: View user moderation reports.
+            tags:
+                - admin
+    /api/v1/admin/reports/{id}:
+        get:
+            operationId: adminReportGet
+            parameters:
+                - description: The id of the report.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The requested report.
+                    schema:
+                        $ref: '#/definitions/adminReport'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: View user moderation report with the given id.
+            tags:
+                - admin
+    /api/v1/admin/reports/{id}/resolve:
+        post:
+            consumes:
+                - application/json
+                - application/xml
+                - multipart/form-data
+            operationId: adminReportResolve
+            parameters:
+                - description: The id of the report.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+                - description: Optional admin comment on the action taken in response to this report. Useful for providing an explanation about what action was taken (if any) before the report was marked as resolved. This will be visible to the user that created the report!
+                  x-example: The reported account was suspended.
+                  in: formData
+                  name: action_taken_comment
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The resolved report.
+                    schema:
+                        $ref: '#/definitions/adminReport'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: Mark a report as resolved.
+            tags:
+                - admin
+    /api/v1/apps:
+        post:
+            consumes:
+                - application/json
+                - application/xml
+                - application/x-www-form-urlencoded
+            description: |-
+                The registered application can be used to obtain an application token.
+                This can then be used to register a new account, or (through user auth) obtain an access token.
+
+                The parameters can also be given in the body of the request, as JSON, if the content-type is set to 'application/json'.
+                The parameters can also be given in the body of the request, as XML, if the content-type is set to 'application/xml'.
+            operationId: appCreate
+            parameters:
+                - description: The name of the application.
+                  in: formData
+                  name: client_name
+                  required: true
+                  type: string
+                  x-go-name: ClientName
+                - description: |-
+                    Where the user should be redirected after authorization.
+
+                    To display the authorization code to the user instead of redirecting to a web page, use `urn:ietf:wg:oauth:2.0:oob` in this parameter.
+                  in: formData
+                  name: redirect_uris
+                  required: true
+                  type: string
+                  x-go-name: RedirectURIs
+                - description: |-
+                    Space separated list of scopes.
+
+                    If no scopes are provided, defaults to `read`.
+                  in: formData
+                  name: scopes
+                  type: string
+                  x-go-name: Scopes
+                - description: A URL to the web page of the app (optional).
+                  in: formData
+                  name: website
+                  type: string
+                  x-go-name: Website
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The newly-created application.
+                    schema:
+                        $ref: '#/definitions/application'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            summary: Register a new application on this instance.
+            tags:
+                - apps
+    /api/v1/blocks:
+        get:
+            description: |-
+                The next and previous queries can be parsed from the returned Link header.
+                Example:
+
+                ```
+                <https://example.org/api/v1/blocks?limit=80&max_id=01FC0SKA48HNSVR6YKZCQGS2V8>; rel="next", <https://example.org/api/v1/blocks?limit=80&min_id=01FC0SKW5JK2Q4EVAV2B462YY0>; rel="prev"
+                ````
+            operationId: blocksGet
+            parameters:
+                - default: 20
+                  description: Number of blocks to return.
+                  in: query
+                  name: limit
+                  type: integer
+                - description: Return only blocks *OLDER* than the given block ID. The block with the specified ID will not be included in the response.
+                  in: query
+                  name: max_id
+                  type: string
+                - description: Return only blocks *NEWER* than the given block ID. The block with the specified ID will not be included in the response.
+                  in: query
+                  name: since_id
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
+                    schema:
+                        items:
+                            $ref: '#/definitions/account'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:blocks
+            summary: Get an array of accounts that requesting account has blocked.
+            tags:
+                - blocks
+    /api/v1/bookmarks:
+        get:
+            description: Get an array of statuses bookmarked in the instance
+            operationId: bookmarksGet
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of bookmarked statuses
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
+                    schema:
+                        items:
+                            $ref: '#/definitions/status'
+                        type: array
+                "401":
+                    description: unauthorized
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:bookmarks
+            tags:
+                - bookmarks
+    /api/v1/custom_emojis:
+        get:
+            operationId: customEmojisGet
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of custom emojis.
+                    schema:
+                        items:
+                            $ref: '#/definitions/emoji'
+                        type: array
+                "401":
+                    description: unauthorized
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:custom_emojis
+            summary: Get an array of custom emojis available on the instance.
+            tags:
+                - custom_emojis
+    /api/v1/favourites:
+        get:
+            description: |-
+                The next and previous queries can be parsed from the returned Link header.
+                Example:
+
+                ```
+                <https://example.org/api/v1/favourites?limit=80&max_id=01FC0SKA48HNSVR6YKZCQGS2V8>; rel="next", <https://example.org/api/v1/favourites?limit=80&min_id=01FC0SKW5JK2Q4EVAV2B462YY0>; rel="prev"
+                ````
+            operationId: favouritesGet
+            parameters:
+                - default: 20
+                  description: Number of statuses to return.
+                  in: query
+                  name: limit
+                  type: integer
+                - description: Return only favourited statuses *OLDER* than the given favourite ID. The status with the corresponding fave ID will not be included in the response.
+                  in: query
+                  name: max_id
+                  type: string
+                - description: Return only favourited statuses *NEWER* than the given favourite ID. The status with the corresponding fave ID will not be included in the response.
+                  in: query
+                  name: min_id
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
+                    schema:
+                        items:
+                            $ref: '#/definitions/status'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:favourites
+            summary: Get an array of statuses that the requesting account has favourited.
+            tags:
+                - favourites
+    /api/v1/featured_tags:
+        get:
+            description: 'THIS ENDPOINT IS CURRENTLY NOT FULLY IMPLEMENTED: it will always return an empty array.'
+            operationId: getFeaturedTags
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    schema:
+                        items:
+                            type: object
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:accounts
+            summary: Get an array of all hashtags that you currently have featured on your profile.
+            tags:
+                - featured_tags
+    /api/v1/follow_requests:
+        get:
+            description: Accounts will be sorted in order of follow request date descending (newest first).
+            operationId: getFollowRequests
+            parameters:
+                - default: 40
+                  description: Number of accounts to return.
+                  in: query
+                  name: limit
+                  type: integer
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
+                    schema:
+                        items:
+                            $ref: '#/definitions/account'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:follows
+            summary: Get an array of accounts that have requested to follow you.
+            tags:
+                - follow_requests
+    /api/v1/follow_requests/{account_id}/authorize:
+        post:
+            description: Accept a follow request and put the requesting account in your 'followers' list.
+            operationId: authorizeFollowRequest
+            parameters:
+                - description: ID of the account requesting to follow you.
+                  in: path
+                  name: account_id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Your relationship to this account.
+                    schema:
+                        $ref: '#/definitions/accountRelationship'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:follows
+            summary: Accept/authorize follow request from the given account ID.
+            tags:
+                - follow_requests
+    /api/v1/follow_requests/{account_id}/reject:
+        post:
+            operationId: rejectFollowRequest
+            parameters:
+                - description: ID of the account requesting to follow you.
+                  in: path
+                  name: account_id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Your relationship to this account.
+                    schema:
+                        $ref: '#/definitions/accountRelationship'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:follows
+            summary: Reject/deny follow request from the given account ID.
+            tags:
+                - follow_requests
+    /api/v1/instance:
+        get:
+            operationId: instanceGetV1
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Instance information.
+                    schema:
+                        $ref: '#/definitions/instanceV1'
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal error
+            summary: View instance information.
+            tags:
+                - instance
+        patch:
+            consumes:
+                - multipart/form-data
+            description: This requires admin permissions on the instance.
+            operationId: instanceUpdate
+            parameters:
+                - allowEmptyValue: true
+                  description: Title to use for the instance.
+                  in: formData
+                  maximum: 40
+                  name: title
+                  type: string
+                - allowEmptyValue: true
+                  description: Username of the contact account. This must be the username of an instance admin.
+                  in: formData
+                  name: contact_username
+                  type: string
+                - allowEmptyValue: true
+                  description: Email address to use as the instance contact.
+                  in: formData
+                  name: contact_email
+                  type: string
+                - allowEmptyValue: true
+                  description: Short description of the instance.
+                  in: formData
+                  maximum: 500
+                  name: short_description
+                  type: string
+                - allowEmptyValue: true
+                  description: Longer description of the instance.
+                  in: formData
+                  maximum: 5000
+                  name: description
+                  type: string
+                - allowEmptyValue: true
+                  description: Terms and conditions of the instance.
+                  in: formData
+                  maximum: 5000
+                  name: terms
+                  type: string
+                - description: Thumbnail image to use for the instance.
+                  in: formData
+                  name: thumbnail
+                  type: file
+                - description: Image description of the submitted instance thumbnail.
+                  in: formData
+                  name: thumbnail_description
+                  type: string
+                - description: Header image to use for the instance.
+                  in: formData
+                  name: header
+                  type: file
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The newly updated instance.
+                    schema:
+                        $ref: '#/definitions/instanceV1'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin
+            summary: Update your instance information and/or upload a new avatar/header for the instance.
+            tags:
+                - instance
+    /api/v1/instance/peers:
+        get:
+            operationId: instancePeersGet
+            parameters:
+                - default: open
+                  description: |-
+                    Comma-separated list of filters to apply to results. Recognized filters are:
+                      - `open` -- include peers that are not suspended or silenced
+                      - `suspended` -- include peers that have been suspended.
+
+                    If filter is `open`, only instances that haven't been suspended or silenced will be returned.
+
+                    If filter is `suspended`, only suspended instances will be shown.
+
+                    If filter is `open,suspended`, then all known instances will be returned.
+
+                    If filter is an empty string or not set, then `open` will be assumed as the default.
+                  in: query
+                  name: filter
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: |-
+                        If no filter parameter is provided, or filter is empty, then a legacy, Mastodon-API compatible response will be returned. This will consist of just a 'flat' array of strings like `["example.com", "example.org"]`, which corresponds to domains this instance peers with.
+
+                        If a filter parameter is provided, then an array of objects with at least a `domain` key set on each object will be returned.
+
+                        Domains that are silenced or suspended will also have a key `suspended_at` or `silenced_at` that contains an iso8601 date string. If one of these keys is not present on the domain object, it is open. Suspended instances may in some cases be obfuscated, which means they will have some letters replaced by `*` to make it more difficult for bad actors to target instances with harassment.
+
+                        Whether a flat response or a more detailed response is returned, domains will be sorted alphabetically by hostname.
+                    schema:
+                        items:
+                            $ref: '#/definitions/domain'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            tags:
+                - instance
+    /api/v1/media/{id}:
+        get:
+            operationId: mediaGet
+            parameters:
+                - description: id of the attachment
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The requested media attachment.
+                    schema:
+                        $ref: '#/definitions/attachment'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:media
+            summary: Get a media attachment that you own.
+            tags:
+                - media
+        put:
+            consumes:
+                - application/json
+                - application/xml
+                - application/x-www-form-urlencoded
+            description: |-
+                You must own the media attachment, and the attachment must not yet be attached to a status.
+
+                The parameters can also be given in the body of the request, as JSON, if the content-type is set to 'application/json'.
+                The parameters can also be given in the body of the request, as XML, if the content-type is set to 'application/xml'.
+            operationId: mediaUpdate
+            parameters:
+                - description: id of the attachment to update
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+                - allowEmptyValue: true
+                  description: Image or media description to use as alt-text on the attachment. This is very useful for users of screenreaders! May or may not be required, depending on your instance settings.
+                  in: formData
+                  name: description
+                  type: string
+                - allowEmptyValue: true
+                  default: 0,0
+                  description: 'Focus of the media file. If present, it should be in the form of two comma-separated floats between -1 and 1. For example: `-0.5,0.25`.'
+                  in: formData
+                  name: focus
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The newly-updated media attachment.
+                    schema:
+                        $ref: '#/definitions/attachment'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:media
+            summary: Update a media attachment.
+            tags:
+                - media
+    /api/v1/notifications:
+        get:
+            description: |-
+                The notifications will be returned in descending chronological order (newest first), with sequential IDs (bigger = newer).
+
+                The next and previous queries can be parsed from the returned Link header.
+                Example:
+
+                ```
+                <https://example.org/api/v1/notifications?limit=80&max_id=01FC0SKA48HNSVR6YKZCQGS2V8>; rel="next", <https://example.org/api/v1/notifications?limit=80&since_id=01FC0SKW5JK2Q4EVAV2B462YY0>; rel="prev"
+                ````
+            operationId: notifications
+            parameters:
+                - default: 20
+                  description: Number of notifications to return.
+                  in: query
+                  name: limit
+                  type: integer
+                - in: query
+                  items:
+                    type: string
+                  name: exclude_types
+                  type: array
+                - description: Return only notifications *OLDER* than the given max status ID. The status with the specified ID will not be included in the response.
+                  in: query
+                  name: max_id
+                  type: string
+                - description: |-
+                    Return only notifications *NEWER* than the given since status ID.
+                    The status with the specified ID will not be included in the response.
+                  in: query
+                  name: since_id
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of notifications.
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
+                    schema:
+                        items:
+                            $ref: '#/definitions/notification'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:notifications
+            summary: Get notifications for currently authorized user.
+            tags:
+                - notifications
+        post:
+            description: Will return an empty object `{}` to indicate success.
+            operationId: clearNotifications
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    schema:
+                        type: object
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:notifications
+            summary: Clear/delete all notifications for currently authorized user.
+            tags:
+                - notifications
+    /api/v1/reports:
+        get:
+            description: |-
+                The reports will be returned in descending chronological order (newest first), with sequential IDs (bigger = newer).
+
+                The next and previous queries can be parsed from the returned Link header.
+
+                Example:
+
+                ```
+                <https://example.org/api/v1/reports?limit=20&max_id=01FC0SKA48HNSVR6YKZCQGS2V8>; rel="next", <https://example.org/api/v1/reports?limit=20&min_id=01FC0SKW5JK2Q4EVAV2B462YY0>; rel="prev"
+                ````
+            operationId: reports
+            parameters:
+                - description: If set to true, only resolved reports will be returned. If false, only unresolved reports will be returned. If unset, reports will not be filtered on their resolved status.
+                  in: query
+                  name: resolved
+                  type: boolean
+                - description: Return only reports that target the given account id.
+                  in: query
+                  name: target_account_id
+                  type: string
+                - description: Return only reports *OLDER* than the given max ID. The report with the specified ID will not be included in the response.
+                  in: query
+                  name: max_id
+                  type: string
+                - description: Return only reports *NEWER* than the given since ID. The report with the specified ID will not be included in the response. This parameter is functionally equivalent to min_id.
+                  in: query
+                  name: since_id
+                  type: string
+                - description: Return only reports *NEWER* than the given min ID. The report with the specified ID will not be included in the response. This parameter is functionally equivalent to since_id.
+                  in: query
+                  name: min_id
+                  type: string
+                - default: 20
+                  description: Number of reports to return. If less than 1, will be clamped to 1. If more than 100, will be clamped to 100.
+                  in: query
+                  name: limit
+                  type: integer
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of reports.
+                    schema:
+                        items:
+                            $ref: '#/definitions/report'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:reports
+            summary: See reports created by the requesting account.
+            tags:
+                - reports
+        post:
+            consumes:
+                - application/json
+                - application/xml
+                - application/x-www-form-urlencoded
+            operationId: reportCreate
+            parameters:
+                - description: ID of the account to report.
+                  x-example: 01GPE75FXSH2EGFBF85NXPH3KP
+                  in: formData
+                  name: account_id
+                  required: true
+                  type: string
+                  x-go-name: AccountID
+                - description: IDs of statuses to attach to the report to provide additional context.
+                  x-example:
+                    - 01GPE76N4SBVRZ8K24TW51ZZQ4
+                    - 01GPE76WN9JZE62EPT3Q9FRRD4
+                  in: formData
+                  items:
+                    type: string
+                  name: status_ids
+                  type: array
+                  x-go-name: StatusIDs
+                - description: The reason for the report. Default maximum of 1000 characters.
+                  x-example: Anti-Blackness, transphobia.
+                  in: formData
+                  name: comment
+                  type: string
+                  x-go-name: Comment
+                - default: false
+                  description: If the account is remote, should the report be forwarded to the remote admin?
+                  x-example: true
+                  in: formData
+                  name: forward
+                  type: boolean
+                  x-go-name: Forward
+                - default: other
+                  description: |-
+                    Specify if the report is due to spam, violation of enumerated instance rules, or some other reason.
+                    Currently only 'other' is supported.
+                  x-example: other
+                  in: formData
+                  name: category
+                  type: string
+                  x-go-name: Category
+                - description: |-
+                    IDs of rules on this instance which have been broken according to the reporter.
+                    This is currently not supported, provided only for API compatibility.
+                  x-example:
+                    - 1
+                    - 2
+                    - 3
+                  in: formData
+                  items:
+                    format: int64
+                    type: integer
+                  name: rule_ids
+                  type: array
+                  x-go-name: RuleIDs
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The created report.
+                    schema:
+                        $ref: '#/definitions/report'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:reports
+            summary: Create a new user report with the given parameters.
+            tags:
+                - reports
+    /api/v1/reports/{id}:
+        get:
+            operationId: reportGet
+            parameters:
+                - description: ID of the report
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The requested report.
+                    schema:
+                        $ref: '#/definitions/report'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:reports
+            summary: Get one report with the given id.
+            tags:
+                - reports
+    /api/v1/search:
+        get:
+            description: If statuses are in the result, they will be returned in descending chronological order (newest first), with sequential IDs (bigger = newer).
+            operationId: searchGet
+            parameters:
+                - description: If type is `statuses`, then statuses returned will be authored only by this account.
+                  in: query
+                  name: account_id
+                  type: string
+                  x-go-name: AccountID
+                - description: |-
+                    Return results *older* than this id.
+
+                    The entry with this ID will not be included in the search results.
+                  in: query
+                  name: max_id
+                  type: string
+                  x-go-name: MaxID
+                - description: |-
+                    Return results *newer* than this id.
+
+                    The entry with this ID will not be included in the search results.
+                  in: query
+                  name: min_id
+                  type: string
+                  x-go-name: MinID
+                - description: |-
+                    Type of the search query to perform.
+
+                    Must be one of: `accounts`, `hashtags`, `statuses`.
+                  in: query
+                  name: type
+                  required: true
+                  type: string
+                  x-go-name: Type
+                - default: false
+                  description: Filter out tags that haven't been reviewed and approved by an instance admin.
+                  in: query
+                  name: exclude_unreviewed
+                  type: boolean
+                  x-go-name: ExcludeUnreviewed
+                - description: |-
+                    String to use as a search query.
+
+                    For accounts, this should be in the format `@someaccount@some.instance.com`, or the format `https://some.instance.com/@someaccount`
+
+                    For a status, this can be in the format: `https://some.instance.com/@someaccount/SOME_ID_OF_A_STATUS`
+                  in: query
+                  name: q
+                  required: true
+                  type: string
+                  x-go-name: Query
+                - default: false
+                  description: Attempt to resolve the query by performing a remote webfinger lookup, if the query includes a remote host.
+                  in: query
+                  name: resolve
+                  type: boolean
+                  x-go-name: Resolve
+                - default: 20
+                  description: Maximum number of results to load, per type.
+                  format: int64
+                  in: query
+                  maximum: 40
+                  minimum: 1
+                  name: limit
+                  type: integer
+                  x-go-name: Limit
+                - default: 0
+                  description: Offset for paginating search results.
+                  format: int64
+                  in: query
+                  name: offset
+                  type: integer
+                  x-go-name: Offset
+                - default: false
+                  description: Only include accounts that the searching account is following.
+                  in: query
+                  name: following
+                  type: boolean
+                  x-go-name: Following
+            responses:
+                "200":
+                    description: Results of the search.
+                    schema:
+                        items:
+                            $ref: '#/definitions/searchResult'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:search
+            summary: Search for statuses, accounts, or hashtags, on this instance or elsewhere.
+            tags:
+                - search
+    /api/v1/statuses:
+        post:
+            consumes:
+                - application/json
+                - application/xml
+                - application/x-www-form-urlencoded
+            description: |-
+                The parameters can also be given in the body of the request, as JSON, if the content-type is set to 'application/json'.
+                The parameters can also be given in the body of the request, as XML, if the content-type is set to 'application/xml'.
+            operationId: statusCreate
+            parameters:
+                - description: |-
+                    Text content of the status.
+                    If media_ids is provided, this becomes optional.
+                    Attaching a poll is optional while status is provided.
+                  in: formData
+                  name: status
+                  type: string
+                  x-go-name: Status
+                - description: |-
+                    Array of Attachment ids to be attached as media.
+                    If provided, status becomes optional, and poll cannot be used.
+
+                    If the status is being submitted as a form, the key is 'media_ids[]',
+                    but if it's json or xml, the key is 'media_ids'.
+                  in: formData
+                  items:
+                    type: string
+                  name: media_ids
+                  type: array
+                  x-go-name: MediaIDs
+                - description: ID of the status being replied to, if status is a reply.
+                  in: formData
+                  name: in_reply_to_id
+                  type: string
+                  x-go-name: InReplyToID
+                - description: Status and attached media should be marked as sensitive.
+                  in: formData
+                  name: sensitive
+                  type: boolean
+                  x-go-name: Sensitive
+                - description: |-
+                    Text to be shown as a warning or subject before the actual content.
+                    Statuses are generally collapsed behind this field.
+                  in: formData
+                  name: spoiler_text
+                  type: string
+                  x-go-name: SpoilerText
+                - description: Visibility of the posted status.
+                  in: formData
+                  name: visibility
+                  type: string
+                  x-go-name: Visibility
+                - description: |-
+                    ISO 8601 Datetime at which to schedule a status.
+                    Providing this parameter will cause ScheduledStatus to be returned instead of Status.
+                    Must be at least 5 minutes in the future.
+                  in: formData
+                  name: scheduled_at
+                  type: string
+                  x-go-name: ScheduledAt
+                - description: ISO 639 language code for this status.
+                  in: formData
+                  name: language
+                  type: string
+                  x-go-name: Language
+                - description: Format to use when parsing this status.
+                  in: formData
+                  name: format
+                  type: string
+                  x-go-name: Format
+                - description: This status will be federated beyond the local timeline(s).
+                  in: query
+                  name: federated
+                  type: boolean
+                  x-go-name: Federated
+                - description: This status can be boosted/reblogged.
+                  in: query
+                  name: boostable
+                  type: boolean
+                  x-go-name: Boostable
+                - description: This status can be replied to.
+                  in: query
+                  name: replyable
+                  type: boolean
+                  x-go-name: Replyable
+                - description: This status can be liked/faved.
+                  in: query
+                  name: likeable
+                  type: boolean
+                  x-go-name: Likeable
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The newly created status.
+                    schema:
+                        $ref: '#/definitions/status'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:statuses
+            summary: Create a new status.
+            tags:
+                - statuses
+    /api/v1/statuses/{id}:
+        delete:
+            description: |-
+                The deleted status will be returned in the response. The `text` field will contain the original text of the status as it was submitted.
+                This is useful when doing a 'delete and redraft' type operation.
+            operationId: statusDelete
+            parameters:
+                - description: Target status ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The status that was just deleted.
+                    schema:
+                        $ref: '#/definitions/status'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:statuses
+            summary: Delete status with the given ID. The status must belong to you.
+            tags:
+                - statuses
+        get:
+            operationId: statusGet
+            parameters:
+                - description: Target status ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The requested status.
+                    schema:
+                        $ref: '#/definitions/status'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:statuses
+            summary: View status with the given ID.
+            tags:
+                - statuses
+    /api/v1/statuses/{id}/bookmark:
+        post:
+            operationId: statusBookmark
+            parameters:
+                - description: Target status ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The status.
+                    schema:
+                        $ref: '#/definitions/status'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:statuses
+            summary: Bookmark status with the given ID.
+            tags:
+                - statuses
+    /api/v1/statuses/{id}/context:
+        get:
+            description: The returned statuses will be ordered in a thread structure, so they are suitable to be displayed in the order in which they were returned.
+            operationId: statusContext
+            parameters:
+                - description: Target status ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Status context object.
+                    schema:
+                        $ref: '#/definitions/statusContext'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:statuses
+            summary: Return ancestors and descendants of the given status.
+            tags:
+                - statuses
+    /api/v1/statuses/{id}/favourite:
+        post:
+            operationId: statusFave
+            parameters:
+                - description: Target status ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The newly faved status.
+                    schema:
+                        $ref: '#/definitions/status'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:statuses
+            summary: Star/like/favourite the given status, if permitted.
+            tags:
+                - statuses
+    /api/v1/statuses/{id}/favourited_by:
+        get:
+            operationId: statusFavedBy
+            parameters:
+                - description: Target status ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    schema:
+                        items:
+                            $ref: '#/definitions/account'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:accounts
+            summary: View accounts that have faved/starred/liked the target status.
+            tags:
+                - statuses
+    /api/v1/statuses/{id}/reblog:
+        post:
+            description: |-
+                If the target status is rebloggable/boostable, it will be shared with your followers.
+                This is equivalent to an ActivityPub 'Announce' activity.
+            operationId: statusReblog
+            parameters:
+                - description: Target status ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The boost of the status.
+                    schema:
+                        $ref: '#/definitions/status'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:statuses
+            summary: Reblog/boost status with the given ID.
+            tags:
+                - statuses
+    /api/v1/statuses/{id}/reblogged_by:
+        get:
+            operationId: statusBoostedBy
+            parameters:
+                - description: Target status ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    schema:
+                        items:
+                            $ref: '#/definitions/account'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+            security:
+                - OAuth2 Bearer:
+                    - read:accounts
+            summary: View accounts that have reblogged/boosted the target status.
+            tags:
+                - statuses
+    /api/v1/statuses/{id}/unbookmark:
+        post:
+            operationId: statusUnbookmark
+            parameters:
+                - description: Target status ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The status.
+                    schema:
+                        $ref: '#/definitions/status'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:statuses
+            summary: Unbookmark status with the given ID.
+            tags:
+                - statuses
+    /api/v1/statuses/{id}/unfavourite:
+        post:
+            operationId: statusUnfave
+            parameters:
+                - description: Target status ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The unfaved status.
+                    schema:
+                        $ref: '#/definitions/status'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:statuses
+            summary: Unstar/unlike/unfavourite the given status.
+            tags:
+                - statuses
+    /api/v1/statuses/{id}/unreblog:
+        post:
+            operationId: statusUnreblog
+            parameters:
+                - description: Target status ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The unboosted status.
+                    schema:
+                        $ref: '#/definitions/status'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:statuses
+            summary: Unreblog/unboost status with the given ID.
+            tags:
+                - statuses
+    /api/v1/streaming:
+        get:
+            description: |-
+                The scheme used should *always* be `wss`. The streaming basepath can be viewed at `/api/v1/instance`.
+
+                On a successful connection, a code `101` will be returned, which indicates that the connection is being upgraded to a secure websocket connection.
+
+                As long as the connection is open, various message types will be streamed into it.
+
+                GoToSocial will ping the connection every 30 seconds to check whether the client is still receiving.
+
+                If the ping fails, or something else goes wrong during transmission, then the connection will be dropped, and the client will be expected to start it again.
+            operationId: streamGet
+            parameters:
+                - description: Access token for the requesting account.
+                  in: query
+                  name: access_token
+                  required: true
+                  type: string
+                - description: |-
+                    Type of stream to request.
+
+                    Options are:
+
+                    `user`: receive updates for the account's home timeline.
+                    `public`: receive updates for the public timeline.
+                    `public:local`: receive updates for the local timeline.
+                    `hashtag`: receive updates for a given hashtag.
+                    `hashtag:local`: receive local updates for a given hashtag.
+                    `list`: receive updates for a certain list of accounts.
+                    `direct`: receive updates for direct messages.
+                  in: query
+                  name: stream
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "101":
+                    description: ""
+                    schema:
+                        properties:
+                            event:
+                                description: |-
+                                    The type of event being received.
+
+                                    `update`: a new status has been received.
+                                    `notification`: a new notification has been received.
+                                    `delete`: a status has been deleted.
+                                    `filters_changed`: not implemented.
+                                enum:
+                                    - update
+                                    - notification
+                                    - delete
+                                    - filters_changed
+                                type: string
+                            payload:
+                                description: |-
+                                    The payload of the streamed message.
+                                    Different depending on the `event` type.
+
+                                    If present, it should be parsed as a string.
+
+                                    If `event` = `update`, then the payload will be a JSON string of a status.
+                                    If `event` = `notification`, then the payload will be a JSON string of a notification.
+                                    If `event` = `delete`, then the payload will be a status ID.
+                                example: '{"id":"01FC3TZ5CFG6H65GCKCJRKA669","created_at":"2021-08-02T16:25:52Z","sensitive":false,"spoiler_text":"","visibility":"public","language":"en","uri":"https://gts.superseriousbusiness.org/users/dumpsterqueer/statuses/01FC3TZ5CFG6H65GCKCJRKA669","url":"https://gts.superseriousbusiness.org/@dumpsterqueer/statuses/01FC3TZ5CFG6H65GCKCJRKA669","replies_count":0,"reblogs_count":0,"favourites_count":0,"favourited":false,"reblogged":false,"muted":false,"bookmarked":fals…//gts.superseriousbusiness.org/fileserver/01JNN207W98SGG3CBJ76R5MVDN/header/original/019036W043D8FXPJKSKCX7G965.png","header_static":"https://gts.superseriousbusiness.org/fileserver/01JNN207W98SGG3CBJ76R5MVDN/header/small/019036W043D8FXPJKSKCX7G965.png","followers_count":33,"following_count":28,"statuses_count":126,"last_status_at":"2021-08-02T16:25:52Z","emojis":[],"fields":[]},"media_attachments":[],"mentions":[],"tags":[],"emojis":[],"card":null,"poll":null,"text":"a"}'
+                                type: string
+                            stream:
+                                items:
+                                    enum:
+                                        - user
+                                        - public
+                                        - public:local
+                                        - hashtag
+                                        - hashtag:local
+                                        - list
+                                        - direct
+                                    type: string
+                                type: array
+                        type: object
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+            schemes:
+                - wss
+            security:
+                - OAuth2 Bearer:
+                    - read:streaming
+            summary: Initiate a websocket connection for live streaming of statuses and notifications.
+            tags:
+                - streaming
+    /api/v1/timelines/home:
+        get:
+            description: |-
+                The statuses will be returned in descending chronological order (newest first), with sequential IDs (bigger = newer).
+
+                The returned Link header can be used to generate the previous and next queries when scrolling up or down a timeline.
+
+                Example:
+
+                ```
+                <https://example.org/api/v1/timelines/home?limit=20&max_id=01FC3GSQ8A3MMJ43BPZSGEG29M>; rel="next", <https://example.org/api/v1/timelines/home?limit=20&min_id=01FC3KJW2GYXSDDRA6RWNDM46M>; rel="prev"
+                ````
+            operationId: homeTimeline
+            parameters:
+                - description: Return only statuses *OLDER* than the given max status ID. The status with the specified ID will not be included in the response.
+                  in: query
+                  name: max_id
+                  type: string
+                - description: Return only statuses *NEWER* than the given since status ID. The status with the specified ID will not be included in the response.
+                  in: query
+                  name: since_id
+                  type: string
+                - description: Return only statuses *NEWER* than the given since status ID. The status with the specified ID will not be included in the response.
+                  in: query
+                  name: min_id
+                  type: string
+                - default: 20
+                  description: Number of statuses to return.
+                  in: query
+                  name: limit
+                  type: integer
+                - default: false
+                  description: Show only statuses posted by local accounts.
+                  in: query
+                  name: local
+                  type: boolean
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of statuses.
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
+                    schema:
+                        items:
+                            $ref: '#/definitions/status'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+            security:
+                - OAuth2 Bearer:
+                    - read:statuses
+            summary: See statuses/posts by accounts you follow.
+            tags:
+                - timelines
+    /api/v1/timelines/public:
+        get:
+            description: |-
+                The statuses will be returned in descending chronological order (newest first), with sequential IDs (bigger = newer).
+
+                The returned Link header can be used to generate the previous and next queries when scrolling up or down a timeline.
+
+                Example:
+
+                ```
+                <https://example.org/api/v1/timelines/public?limit=20&max_id=01FC3GSQ8A3MMJ43BPZSGEG29M>; rel="next", <https://example.org/api/v1/timelines/public?limit=20&min_id=01FC3KJW2GYXSDDRA6RWNDM46M>; rel="prev"
+                ````
+            operationId: publicTimeline
+            parameters:
+                - description: Return only statuses *OLDER* than the given max status ID. The status with the specified ID will not be included in the response.
+                  in: query
+                  name: max_id
+                  type: string
+                - description: Return only statuses *NEWER* than the given since status ID. The status with the specified ID will not be included in the response.
+                  in: query
+                  name: since_id
+                  type: string
+                - description: Return only statuses *NEWER* than the given since status ID. The status with the specified ID will not be included in the response.
+                  in: query
+                  name: min_id
+                  type: string
+                - default: 20
+                  description: Number of statuses to return.
+                  in: query
+                  name: limit
+                  type: integer
+                - default: false
+                  description: Show only statuses posted by local accounts.
+                  in: query
+                  name: local
+                  type: boolean
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of statuses.
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
+                    schema:
+                        items:
+                            $ref: '#/definitions/status'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+            security:
+                - OAuth2 Bearer:
+                    - read:statuses
+            summary: See public statuses/posts that your instance is aware of.
+            tags:
+                - timelines
+    /api/v1/user/password_change:
+        post:
+            consumes:
+                - application/json
+                - application/xml
+                - application/x-www-form-urlencoded
+            description: |-
+                The parameters can also be given in the body of the request, as JSON, if the content-type is set to 'application/json'.
+                The parameters can also be given in the body of the request, as XML, if the content-type is set to 'application/xml'.
+            operationId: userPasswordChange
+            parameters:
+                - description: User's previous password.
+                  in: formData
+                  name: old_password
+                  required: true
+                  type: string
+                  x-go-name: OldPassword
+                - description: |-
+                    Desired new password.
+                    If the password does not have high enough entropy, it will be rejected.
+                    See https://github.com/wagslane/go-password-validator
+                  in: formData
+                  name: new_password
+                  required: true
+                  type: string
+                  x-go-name: NewPassword
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Change successful
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal error
+            security:
+                - OAuth2 Bearer:
+                    - write:user
+            summary: Change the password of authenticated user.
+            tags:
+                - user
+    /api/v2/instance:
+        get:
+            operationId: instanceGetV2
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Instance information.
+                    schema:
+                        $ref: '#/definitions/instanceV2'
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal error
+            summary: View instance information.
+            tags:
+                - instance
+    /nodeinfo/2.0:
+        get:
+            description: 'See: https://nodeinfo.diaspora.software/schema.html'
+            operationId: nodeInfoGet
+            produces:
+                - application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.0#"
+            responses:
+                "200":
+                    description: ""
+                    schema:
+                        $ref: '#/definitions/nodeinfo'
+            summary: Returns a compliant nodeinfo response to node info queries.
+            tags:
+                - nodeinfo
+    /users/{username}/outbox:
+        get:
+            description: |-
+                Note that the response will be a Collection with a page as `first`, as shown below, if `page` is `false`.
+
+                If `page` is `true`, then the response will be a single `CollectionPage` without the wrapping `Collection`.
+
+                HTTP signature is required on the request.
+            operationId: s2sOutboxGet
+            parameters:
+                - description: Username of the account.
+                  in: path
+                  name: username
+                  required: true
+                  type: string
+                - default: false
+                  description: Return response as a CollectionPage.
+                  in: query
+                  name: page
+                  type: boolean
+                - description: Minimum ID of the next status, used for paging.
+                  in: query
+                  name: min_id
+                  type: string
+                - description: Maximum ID of the next status, used for paging.
+                  in: query
+                  name: max_id
+                  type: string
+            produces:
+                - application/activity+json
+            responses:
+                "200":
+                    description: ""
+                    schema:
+                        $ref: '#/definitions/swaggerCollection'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+            summary: Get the public outbox collection for an actor.
+            tags:
+                - s2s/federation
+    /users/{username}/statuses/{status}/replies:
+        get:
+            description: |-
+                Note that the response will be a Collection with a page as `first`, as shown below, if `page` is `false`.
+
+                If `page` is `true`, then the response will be a single `CollectionPage` without the wrapping `Collection`.
+
+                HTTP signature is required on the request.
+            operationId: s2sRepliesGet
+            parameters:
+                - description: Username of the account.
+                  in: path
+                  name: username
+                  required: true
+                  type: string
+                - description: ID of the status.
+                  in: path
+                  name: status
+                  required: true
+                  type: string
+                - default: false
+                  description: Return response as a CollectionPage.
+                  in: query
+                  name: page
+                  type: boolean
+                - default: false
+                  description: Return replies only from accounts other than the status owner.
+                  in: query
+                  name: only_other_accounts
+                  type: boolean
+                - description: Minimum ID of the next status, used for paging.
+                  in: query
+                  name: min_id
+                  type: string
+            produces:
+                - application/activity+json
+            responses:
+                "200":
+                    description: ""
+                    schema:
+                        $ref: '#/definitions/swaggerCollection'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+            summary: Get the replies collection for a status.
+            tags:
+                - s2s/federation
+schemes:
+    - https
+    - http
+securityDefinitions:
+    OAuth2 Application:
+        flow: application
+        scopes:
+            write:accounts: grants write access to accounts
+        tokenUrl: https://example.org/oauth/token
+        type: oauth2
+    OAuth2 Bearer:
+        authorizationUrl: https://example.org/oauth/authorize
+        flow: accessCode
+        scopes:
+            admin: grants admin access to everything
+            admin:accounts: grants admin access to accounts
+            read: grants read access to everything
+            read:accounts: grants read access to accounts
+            read:blocks: grant read access to blocks
+            read:custom_emojis: grant read access to custom_emojis
+            read:favourites: grant read access to favourites
+            read:follows: grant read access to follows
+            read:media: grant read access to media
+            read:notifications: grants read access to notifications
+            read:search: grant read access to searches
+            read:statuses: grants read access to statuses
+            read:streaming: grants read access to streaming api
+            read:user: grants read access to user-level info
+            write: grants write access to everything
+            write:accounts: grants write access to accounts
+            write:blocks: grants write access to blocks
+            write:follows: grants write access to follows
+            write:media: grants write access to media
+            write:statuses: grants write access to statuses
+            write:user: grants write access to user-level info
+        tokenUrl: https://example.org/oauth/token
+        type: oauth2
+swagger: "2.0"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-openapi/loads v0.21.5
 	github.com/go-openapi/spec v0.20.14
 	github.com/go-openapi/strfmt v0.22.0
-	github.com/go-openapi/swag v0.22.7
+	github.com/go-openapi/swag v0.22.8
 	github.com/stretchr/testify v1.8.4
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/go-openapi/spec v0.20.14 h1:7CBlRnw+mtjFGlPDRZmAMnq35cRzI91xj03HVyUi/
 github.com/go-openapi/spec v0.20.14/go.mod h1:8EOhTpBoFiask8rrgwbLC3zmJfz4zsCUueRuPM6GNkw=
 github.com/go-openapi/strfmt v0.22.0 h1:Ew9PnEYc246TwrEspvBdDHS4BVKXy/AOVsfqGDgAcaI=
 github.com/go-openapi/strfmt v0.22.0/go.mod h1:HzJ9kokGIju3/K6ap8jL+OlGAbjpSv27135Yr9OivU4=
-github.com/go-openapi/swag v0.22.7 h1:JWrc1uc/P9cSomxfnsFSVWoE1FW6bNbrVPmpQYpCcR8=
-github.com/go-openapi/swag v0.22.7/go.mod h1:Gl91UqO+btAM0plGGxHqJcQZ1ZTy6jbmridBTsDy8A0=
+github.com/go-openapi/swag v0.22.8 h1:/9RjDSQ0vbFR+NyjGMkFTsA1IA0fmhKSThmfGZjicbw=
+github.com/go-openapi/swag v0.22.8/go.mod h1:6QT22icPLEqAM/z/TChgb4WAveCHF92+2gF0CNjHpPI=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/helpers.go
+++ b/helpers.go
@@ -101,9 +101,17 @@ type errorHelper struct {
 	// A collection of unexported helpers for error construction
 }
 
-func (h *errorHelper) sErr(err errors.Error) *Result {
+func (h *errorHelper) sErr(err errors.Error, recycle bool) *Result {
 	// Builds a Result from standard errors.Error
-	return &Result{Errors: []error{err}}
+	var result *Result
+	if recycle {
+		result = poolOfResults.BorrowResult()
+	} else {
+		result = new(Result)
+	}
+	result.Errors = []error{err}
+
+	return result
 }
 
 func (h *errorHelper) addPointerError(res *Result, err error, ref string, fromPath string) *Result {

--- a/options.go
+++ b/options.go
@@ -31,6 +31,7 @@ type Opts struct {
 	// GET:/v1/{shelve} and GET:/v1/{book}, where the IDs are "shelve/*" and
 	// /"shelve/*/book/*" respectively.
 	StrictPathParamUniqueness bool
+	SkipSchemataResult        bool
 }
 
 var (

--- a/pools.go
+++ b/pools.go
@@ -1,0 +1,373 @@
+package validate
+
+import (
+	"sync"
+
+	"github.com/go-openapi/spec"
+)
+
+var (
+	// memory pools for all validator objects.
+	//
+	// Each pool can be borrowed from and redeemed to.
+	poolOfSchemaValidators      schemaValidatorsPool
+	poolOfObjectValidators      objectValidatorsPool
+	poolOfSliceValidators       sliceValidatorsPool
+	poolOfItemsValidators       itemsValidatorsPool
+	poolOfBasicCommonValidators basicCommonValidatorsPool
+	poolOfHeaderValidators      headerValidatorsPool
+	poolOfParamValidators       paramValidatorsPool
+	poolOfBasicSliceValidators  basicSliceValidatorsPool
+	poolOfNumberValidators      numberValidatorsPool
+	poolOfStringValidators      stringValidatorsPool
+	poolOfSchemaPropsValidators schemaPropsValidatorsPool
+	poolOfFormatValidators      formatValidatorsPool
+	poolOfTypeValidators        typeValidatorsPool
+	poolOfSchemas               schemasPool
+	poolOfResults               resultsPool
+)
+
+func init() {
+	resetPools()
+}
+
+func resetPools() {
+	// NOTE: for testing purpose, we might want to reset pools after calling Validate twice.
+	// The pool is corrupted in that case: calling Put twice inserts a duplicate in the pool
+	// and further calls to Get are mishandled.
+	poolOfSchemaValidators = schemaValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &SchemaValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfObjectValidators = objectValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &objectValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfSliceValidators = sliceValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &schemaSliceValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfItemsValidators = itemsValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &itemsValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfBasicCommonValidators = basicCommonValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &basicCommonValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfHeaderValidators = headerValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &HeaderValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfParamValidators = paramValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &ParamValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfBasicSliceValidators = basicSliceValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &basicSliceValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfNumberValidators = numberValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &numberValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfStringValidators = stringValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &stringValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfSchemaPropsValidators = schemaPropsValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &schemaPropsValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfFormatValidators = formatValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &formatValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfTypeValidators = typeValidatorsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &typeValidator{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfSchemas = schemasPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &spec.Schema{}
+
+				return s
+			},
+		},
+	}
+
+	poolOfResults = resultsPool{
+		Pool: &sync.Pool{
+			New: func() any {
+				s := &Result{}
+
+				return s
+			},
+		},
+	}
+}
+
+type (
+	schemaValidatorsPool struct {
+		*sync.Pool
+	}
+
+	objectValidatorsPool struct {
+		*sync.Pool
+	}
+
+	sliceValidatorsPool struct {
+		*sync.Pool
+	}
+
+	itemsValidatorsPool struct {
+		*sync.Pool
+	}
+
+	basicCommonValidatorsPool struct {
+		*sync.Pool
+	}
+
+	headerValidatorsPool struct {
+		*sync.Pool
+	}
+
+	paramValidatorsPool struct {
+		*sync.Pool
+	}
+
+	basicSliceValidatorsPool struct {
+		*sync.Pool
+	}
+
+	numberValidatorsPool struct {
+		*sync.Pool
+	}
+
+	stringValidatorsPool struct {
+		*sync.Pool
+	}
+
+	schemaPropsValidatorsPool struct {
+		*sync.Pool
+	}
+
+	formatValidatorsPool struct {
+		*sync.Pool
+	}
+
+	typeValidatorsPool struct {
+		*sync.Pool
+	}
+
+	schemasPool struct {
+		*sync.Pool
+	}
+
+	resultsPool struct {
+		*sync.Pool
+	}
+)
+
+func (p schemaValidatorsPool) BorrowValidator() *SchemaValidator {
+	return p.Get().(*SchemaValidator)
+}
+
+func (p schemaValidatorsPool) RedeemValidator(s *SchemaValidator) {
+	// NOTE: s might be nil. In that case, Put is a noop.
+	p.Put(s)
+}
+
+func (p objectValidatorsPool) BorrowValidator() *objectValidator {
+	return p.Get().(*objectValidator)
+}
+
+func (p objectValidatorsPool) RedeemValidator(s *objectValidator) {
+	p.Put(s)
+}
+
+func (p sliceValidatorsPool) BorrowValidator() *schemaSliceValidator {
+	return p.Get().(*schemaSliceValidator)
+}
+
+func (p sliceValidatorsPool) RedeemValidator(s *schemaSliceValidator) {
+	p.Put(s)
+}
+
+func (p itemsValidatorsPool) BorrowValidator() *itemsValidator {
+	return p.Get().(*itemsValidator)
+}
+
+func (p itemsValidatorsPool) RedeemValidator(s *itemsValidator) {
+	p.Put(s)
+}
+
+func (p basicCommonValidatorsPool) BorrowValidator() *basicCommonValidator {
+	return p.Get().(*basicCommonValidator)
+}
+
+func (p basicCommonValidatorsPool) RedeemValidator(s *basicCommonValidator) {
+	p.Put(s)
+}
+
+func (p headerValidatorsPool) BorrowValidator() *HeaderValidator {
+	return p.Get().(*HeaderValidator)
+}
+
+func (p headerValidatorsPool) RedeemValidator(s *HeaderValidator) {
+	p.Put(s)
+}
+
+func (p paramValidatorsPool) BorrowValidator() *ParamValidator {
+	return p.Get().(*ParamValidator)
+}
+
+func (p paramValidatorsPool) RedeemValidator(s *ParamValidator) {
+	p.Put(s)
+}
+
+func (p basicSliceValidatorsPool) BorrowValidator() *basicSliceValidator {
+	return p.Get().(*basicSliceValidator)
+}
+
+func (p basicSliceValidatorsPool) RedeemValidator(s *basicSliceValidator) {
+	p.Put(s)
+}
+
+func (p numberValidatorsPool) BorrowValidator() *numberValidator {
+	return p.Get().(*numberValidator)
+}
+
+func (p numberValidatorsPool) RedeemValidator(s *numberValidator) {
+	p.Put(s)
+}
+
+func (p stringValidatorsPool) BorrowValidator() *stringValidator {
+	return p.Get().(*stringValidator)
+}
+
+func (p stringValidatorsPool) RedeemValidator(s *stringValidator) {
+	p.Put(s)
+}
+
+func (p schemaPropsValidatorsPool) BorrowValidator() *schemaPropsValidator {
+	return p.Get().(*schemaPropsValidator)
+}
+
+func (p schemaPropsValidatorsPool) RedeemValidator(s *schemaPropsValidator) {
+	p.Put(s)
+}
+
+func (p formatValidatorsPool) BorrowValidator() *formatValidator {
+	return p.Get().(*formatValidator)
+}
+
+func (p formatValidatorsPool) RedeemValidator(s *formatValidator) {
+	p.Put(s)
+}
+
+func (p typeValidatorsPool) BorrowValidator() *typeValidator {
+	return p.Get().(*typeValidator)
+}
+
+func (p typeValidatorsPool) RedeemValidator(s *typeValidator) {
+	p.Put(s)
+}
+
+func (p schemasPool) BorrowSchema() *spec.Schema {
+	return p.Get().(*spec.Schema)
+}
+
+func (p schemasPool) RedeemSchema(s *spec.Schema) {
+	p.Put(s)
+}
+
+func (p resultsPool) BorrowResult() *Result {
+	return p.Get().(*Result).cleared()
+}
+
+func (p resultsPool) RedeemResult(s *Result) {
+	if s == emptyResult {
+		return
+	}
+	p.Put(s)
+}

--- a/result.go
+++ b/result.go
@@ -54,6 +54,8 @@ type Result struct {
 
 	cachedFieldSchemta map[FieldKey][]*spec.Schema
 	cachedItemSchemata map[ItemKey][]*spec.Schema
+
+	wantsRedeemOnMerge bool
 }
 
 // FieldKey is a pair of an object and a field, usable as a key for a map.
@@ -118,6 +120,9 @@ func (r *Result) Merge(others ...*Result) *Result {
 		}
 		r.mergeWithoutRootSchemata(other)
 		r.rootObjectSchemata.Append(other.rootObjectSchemata)
+		if other.wantsRedeemOnMerge {
+			poolOfResults.RedeemResult(other)
+		}
 	}
 	return r
 }
@@ -195,6 +200,9 @@ func (r *Result) mergeForField(obj map[string]interface{}, field string, other *
 			schemata: other.rootObjectSchemata,
 		})
 	}
+	if other.wantsRedeemOnMerge {
+		poolOfResults.RedeemResult(other)
+	}
 
 	return r
 }
@@ -218,14 +226,19 @@ func (r *Result) mergeForSlice(slice reflect.Value, i int, other *Result) *Resul
 			schemata: other.rootObjectSchemata,
 		})
 	}
+	if other.wantsRedeemOnMerge {
+		poolOfResults.RedeemResult(other)
+	}
 
 	return r
 }
 
 // addRootObjectSchemata adds the given schemata for the root object of the result.
-// The slice schemata might be reused. I.e. do not modify it after being added to a result.
+//
+// Since the slice schemata might be reused, it is shallow-cloned before saving it into the result.
 func (r *Result) addRootObjectSchemata(s *spec.Schema) {
-	r.rootObjectSchemata.Append(schemata{one: s})
+	clone := *s
+	r.rootObjectSchemata.Append(schemata{one: &clone})
 }
 
 // addPropertySchemata adds the given schemata for the object and field.
@@ -284,6 +297,9 @@ func (r *Result) MergeAsErrors(others ...*Result) *Result {
 			r.AddErrors(other.Errors...)
 			r.AddErrors(other.Warnings...)
 			r.MatchCount += other.MatchCount
+			if other.wantsRedeemOnMerge {
+				poolOfResults.RedeemResult(other)
+			}
 		}
 	}
 	return r
@@ -299,6 +315,9 @@ func (r *Result) MergeAsWarnings(others ...*Result) *Result {
 			r.AddWarnings(other.Errors...)
 			r.AddWarnings(other.Warnings...)
 			r.MatchCount += other.MatchCount
+			if other.wantsRedeemOnMerge {
+				poolOfResults.RedeemResult(other)
+			}
 		}
 	}
 	return r
@@ -369,7 +388,12 @@ func (r *Result) keepRelevantErrors() *Result {
 			strippedWarnings = append(strippedWarnings, fmt.Errorf(strings.TrimPrefix(e.Error(), "IMPORTANT!")))
 		}
 	}
-	strippedResult := new(Result)
+	var strippedResult *Result
+	if r.wantsRedeemOnMerge {
+		strippedResult = poolOfResults.BorrowResult()
+	} else {
+		strippedResult = new(Result)
+	}
 	strippedResult.Errors = strippedErrors
 	strippedResult.Warnings = strippedWarnings
 	return strippedResult
@@ -429,6 +453,27 @@ func (r *Result) AsError() error {
 		return nil
 	}
 	return errors.CompositeValidationError(r.Errors...)
+}
+
+func (r *Result) cleared() *Result {
+	// clear the Result to be reusable. Keep allocated capacity.
+	r.Errors = r.Errors[:0]
+	r.Warnings = r.Warnings[:0]
+	r.MatchCount = 0
+	r.data = nil
+	r.rootObjectSchemata.one = nil
+	r.rootObjectSchemata.multiple = r.rootObjectSchemata.multiple[:0]
+	r.fieldSchemata = r.fieldSchemata[:0]
+	r.itemSchemata = r.itemSchemata[:0]
+	for k := range r.cachedFieldSchemta {
+		delete(r.cachedFieldSchemta, k)
+	}
+	for k := range r.cachedItemSchemata {
+		delete(r.cachedItemSchemata, k)
+	}
+	r.wantsRedeemOnMerge = true // mark this result as eligible for redeem when merged into another
+
+	return r
 }
 
 // schemata is an arbitrary number of schemata. It does a distinction between zero,

--- a/schema_option.go
+++ b/schema_option.go
@@ -18,6 +18,9 @@ package validate
 type SchemaValidatorOptions struct {
 	EnableObjectArrayTypeCheck    bool
 	EnableArrayMustHaveItemsCheck bool
+	recycleValidators             bool
+	recycleResult                 bool
+	skipSchemataResult            bool
 }
 
 // Option sets optional rules for schema validation
@@ -45,10 +48,36 @@ func SwaggerSchema(enable bool) Option {
 	}
 }
 
-// Options returns current options
+// WithRecycleValidators saves memory allocations and makes validators
+// available for a single use of Validate() only.
+//
+// When a validator is recycled, called MUST not call the Validate() method twice.
+func WithRecycleValidators(enable bool) Option {
+	return func(svo *SchemaValidatorOptions) {
+		svo.recycleValidators = enable
+	}
+}
+
+func withRecycleResults(enable bool) Option {
+	return func(svo *SchemaValidatorOptions) {
+		svo.recycleResult = enable
+	}
+}
+
+// WithSkipSchemataResult skips the deep audit payload stored in validation Result
+func WithSkipSchemataResult(enable bool) Option {
+	return func(svo *SchemaValidatorOptions) {
+		svo.skipSchemataResult = enable
+	}
+}
+
+// Options returns the current set of options
 func (svo SchemaValidatorOptions) Options() []Option {
 	return []Option{
 		EnableObjectArrayTypeCheck(svo.EnableObjectArrayTypeCheck),
 		EnableArrayMustHaveItemsCheck(svo.EnableArrayMustHaveItemsCheck),
+		WithRecycleValidators(svo.recycleValidators),
+		withRecycleResults(svo.recycleResult),
+		WithSkipSchemataResult(svo.skipSchemataResult),
 	}
 }

--- a/schema_option_test.go
+++ b/schema_option_test.go
@@ -16,13 +16,50 @@ package validate
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestEnableObjectArrayTypeCheck(t *testing.T) {
-	opts := &SchemaValidatorOptions{}
-	setter := EnableObjectArrayTypeCheck(true)
-	setter(opts)
-	if !opts.EnableObjectArrayTypeCheck {
-		t.Errorf("Expect 'EnableObjectArrayTypeCheck' is true, got false")
-	}
+func TestSchemaOptions(t *testing.T) {
+	t.Run("EnableObjectArrayTypeCheck", func(t *testing.T) {
+		opts := &SchemaValidatorOptions{}
+		setter := EnableObjectArrayTypeCheck(true)
+		setter(opts)
+		require.True(t, opts.EnableObjectArrayTypeCheck)
+	})
+
+	t.Run("skipSchemataResult", func(t *testing.T) {
+		opts := &SchemaValidatorOptions{}
+		setter := WithSkipSchemataResult(true)
+		setter(opts)
+		require.True(t, opts.skipSchemataResult)
+	})
+
+	t.Run("default Options()", func(t *testing.T) {
+		opts := &SchemaValidatorOptions{}
+		setters := opts.Options()
+
+		target := &SchemaValidatorOptions{}
+		for _, apply := range setters {
+			apply(target)
+		}
+		require.Equal(t, opts, target)
+	})
+
+	t.Run("all set Options()", func(t *testing.T) {
+		opts := &SchemaValidatorOptions{
+			EnableObjectArrayTypeCheck:    true,
+			EnableArrayMustHaveItemsCheck: true,
+			recycleValidators:             true,
+			recycleResult:                 true,
+			skipSchemataResult:            true,
+		}
+		setters := opts.Options()
+
+		target := &SchemaValidatorOptions{}
+		for _, apply := range setters {
+			apply(target)
+		}
+		require.Equal(t, opts, target)
+	})
 }

--- a/schema_props_test.go
+++ b/schema_props_test.go
@@ -17,16 +17,218 @@ package validate
 import (
 	"testing"
 
+	"github.com/go-openapi/spec"
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Test edge cases in schema_props_validator which are difficult
 // to simulate with specs
 // (this one is a trivial, just to check all methods are filled)
 func TestSchemaPropsValidator_EdgeCases(t *testing.T) {
-	s := newSchemaPropsValidator(
-		"", "", nil, nil, nil, nil, nil, nil, strfmt.Default, nil)
-	s.SetPath("path")
-	assert.Equal(t, "path", s.Path)
+	t.Run("should validate props against empty validator", func(t *testing.T) {
+		s := newSchemaPropsValidator(
+			"", "", nil, nil, nil, nil, nil, nil, strfmt.Default, nil)
+		s.SetPath("path")
+		assert.Equal(t, "path", s.Path)
+	})
+
+	t.Run("with allOf", func(t *testing.T) {
+		makeValidator := func() EntityValidator {
+			return newSchemaPropsValidator(
+				"path", "body",
+				[]spec.Schema{
+					*spec.StringProperty(),
+					*spec.StrFmtProperty("date"),
+				}, nil, nil, nil, nil, nil, strfmt.Default, &SchemaValidatorOptions{recycleValidators: true})
+		}
+
+		t.Run("should validate date string", func(t *testing.T) {
+			s := makeValidator()
+
+			const data = "2024-01-25"
+			res := s.Validate(data)
+			require.NotNil(t, res)
+			require.Empty(t, res.Errors)
+
+			t.Run("validator should run once", func(t *testing.T) {
+				// we should not do that: the pool chain list is populated with a duplicate: needs a reset
+				t.Cleanup(resetPools)
+				require.Panics(t, func() {
+					_ = s.Validate(data)
+				})
+			})
+		})
+
+		t.Run("should NOT validate unformatted string", func(t *testing.T) {
+			s := makeValidator()
+
+			const data = "string_value"
+			res := s.Validate(data)
+			require.NotNil(t, res)
+			require.NotEmpty(t, res.Errors)
+		})
+
+		t.Run("should NOT validate number", func(t *testing.T) {
+			s := makeValidator()
+
+			const data = 1
+			res := s.Validate(data)
+			require.NotNil(t, res)
+			require.NotEmpty(t, res.Errors)
+		})
+	})
+
+	t.Run("with oneOf", func(t *testing.T) {
+		makeValidator := func() EntityValidator {
+			return newSchemaPropsValidator(
+				"path", "body",
+				nil,
+				[]spec.Schema{
+					*spec.Int64Property(),
+					*spec.StrFmtProperty("date"),
+				}, nil, nil, nil, nil, strfmt.Default, &SchemaValidatorOptions{recycleValidators: true})
+		}
+
+		t.Run("should validate date string", func(t *testing.T) {
+			s := makeValidator()
+
+			const data = "2024-01-01"
+			res := s.Validate(data)
+			require.NotNil(t, res)
+			require.Empty(t, res.Errors)
+		})
+
+		t.Run("should validate number", func(t *testing.T) {
+			s := makeValidator()
+
+			const data = 1
+			res := s.Validate(data)
+			require.NotNil(t, res)
+			require.Empty(t, res.Errors)
+		})
+	})
+
+	t.Run("with anyOf", func(t *testing.T) {
+		makeValidator := func() EntityValidator {
+			return newSchemaPropsValidator(
+				"path", "body",
+				nil,
+				nil,
+				[]spec.Schema{
+					*spec.StringProperty(),
+					*spec.StrFmtProperty("date"),
+				}, nil, nil, nil, strfmt.Default, &SchemaValidatorOptions{recycleValidators: true})
+		}
+
+		t.Run("should validate date string", func(t *testing.T) {
+			s := makeValidator()
+
+			const data = "2024-01-01"
+			res := s.Validate(data)
+			require.NotNil(t, res)
+			require.Empty(t, res.Errors)
+		})
+
+		t.Run("should validate unformatted string", func(t *testing.T) {
+			s := makeValidator()
+
+			const data = "string_value"
+			res := s.Validate(data)
+			require.NotNil(t, res)
+			require.Empty(t, res.Errors)
+		})
+	})
+
+	t.Run("with not", func(t *testing.T) {
+		makeValidator := func() EntityValidator {
+			return newSchemaPropsValidator(
+				"path", "body",
+				nil,
+				nil,
+				nil,
+				spec.StringProperty(),
+				nil, nil, strfmt.Default, &SchemaValidatorOptions{recycleValidators: true})
+		}
+
+		t.Run("should validate number", func(t *testing.T) {
+			s := makeValidator()
+
+			const data = 1
+			res := s.Validate(data)
+			require.NotNil(t, res)
+			require.Empty(t, res.Errors)
+		})
+
+		t.Run("should NOT validate string", func(t *testing.T) {
+			s := makeValidator()
+
+			const data = "string_value"
+			res := s.Validate(data)
+			require.NotNil(t, res)
+			require.NotEmpty(t, res.Errors)
+		})
+	})
+
+	t.Run("with nested schema props", func(t *testing.T) {
+		makeValidator := func() EntityValidator {
+			return newSchemaValidator(
+				&spec.Schema{
+					SchemaProps: spec.SchemaProps{
+						AllOf: []spec.Schema{
+							{
+								SchemaProps: spec.SchemaProps{
+									OneOf: []spec.Schema{
+										{
+											SchemaProps: spec.SchemaProps{
+												AnyOf: []spec.Schema{
+													{
+														SchemaProps: spec.SchemaProps{
+															Not: spec.StringProperty(),
+														},
+													},
+													*spec.BoolProperty(),
+												},
+											},
+										},
+										*spec.StringProperty(),
+									},
+								},
+							},
+							*spec.Int64Property(),
+						},
+					},
+				},
+				nil,
+				"root",
+				strfmt.Default, &SchemaValidatorOptions{recycleValidators: true})
+		}
+
+		t.Run("should validate number", func(t *testing.T) {
+			s := makeValidator()
+
+			const data = 1
+			res := s.Validate(data)
+			require.NotNil(t, res)
+			require.Empty(t, res.Errors)
+		})
+
+		t.Run("should NOT validate string", func(t *testing.T) {
+			s := makeValidator()
+
+			const data = "string_value"
+			res := s.Validate(data)
+			require.NotNil(t, res)
+			require.NotEmpty(t, res.Errors)
+		})
+
+		t.Run("should exit early and redeem children validator", func(t *testing.T) {
+			s := makeValidator()
+
+			res := s.Validate(nil)
+			require.NotNil(t, res)
+			require.Empty(t, res.Errors)
+		})
+	})
 }

--- a/spec_messages.go
+++ b/spec_messages.go
@@ -187,6 +187,8 @@ const (
 
 	// UnusedResponseWarning ...
 	UnusedResponseWarning = "response %q is not used anywhere"
+
+	InvalidObject = "expected an object in %q.%s"
 )
 
 // Additional error codes
@@ -346,6 +348,9 @@ func invalidParameterDefinitionAsSchemaMsg(path, method, operationID string) err
 }
 func parameterValidationTypeMismatchMsg(param, path, typ string) errors.Error {
 	return errors.New(errors.CompositeErrorCode, ParamValidationTypeMismatch, param, path, typ)
+}
+func invalidObjectMsg(path, in string) errors.Error {
+	return errors.New(errors.CompositeErrorCode, InvalidObject, path, in)
 }
 
 // disabled

--- a/spec_test.go
+++ b/spec_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/loads/fmts"
@@ -910,4 +911,20 @@ func Test_Issue2137(t *testing.T) {
 		}
 	}
 	assert.True(t, found)
+}
+
+func Test_Examples(t *testing.T) {
+	fp := filepath.Join("fixtures", "bugs", "2649", "swagger.yaml")
+
+	doc, err := loads.Spec(fp)
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+
+	validator := NewSpecValidator(doc.Schema(), strfmt.Default)
+	validator.Options.SkipSchemataResult = true
+
+	res, _ := validator.Validate(doc)
+	if !assert.Truef(t, res.IsValid(), "expected spec to be valid") {
+		spew.Dump(res.Errors)
+	}
 }


### PR DESCRIPTION
This PR is a follow-up on https://github.com/go-openapi/validate/pull/169, which cames with innocuous changes, but already
reduced the total number of allocations when validating a swagger spec.

We reduce further the pressure on go's GC by pooling temporarily
allocated objects: validators and results.

When recursively allocating validators, calls to "Validate()" redeem to the pool the allocated
validator. This means that a validator is usable only once.

A similar approach is taken for `Result`s: upon merge, the merged result
is redeemed to the pool.

Eventually, temporarily allocated `spec.Schema`s are also pooled.

In order not to break existing interfaces, this is enabled by default
only when validating a spec (`Spec()`) or when using
`AgainstSchema()`.

Another option at the spec level allows for skipping the gathering of schemas
into the result ("schemata"): these schemas must be cloned to remain
valid after their parent is redeemed to the pool.

Comment on the benchmark:

CPU profiling shows that about 30% of the CPU time is spent managing
garbage.

Memory profiling shows that our benchmark (validating the k8s API spec) goes
down from 25M allocated objects down to ~ 17M (https://github.com/go-openapi/validate/pull/169 went down from 60M to 25M).

The `Validate` method generates only ~ 5M of those, out of which
~ 4M are caused by the schema unmarshaling & expansion and 1M by string
allocations for the validator "path".
Unfortunately, classic string interning methods don't work well with this dynamic "path",
so I leave it there.

Integration tests (https://github.com/go-swagger/go-swagger/pull/3064)
show a significant improvement when running go-swagger validate in codegen.

* contributes: https://github.com/go-swagger/go-swagger/issues/2649

Further improvements would most likely come from optimizing the
validation of defaults and examples (which amount for 2M allocs).

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>