### PR TITLE
test: stop executing the live remote-URL doc examples

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -57,8 +57,12 @@ func ExampleSpec_second() {
 		fmt.Println("Could not load this spec:", err)
 	}
 
-	// Output:
-	// This spec is valid
+	// NOTE: this example loads a spec from a live remote URL, so it is intentionally left
+	// without an "// Output:" directive: Go compiles it (keeping it from bit-rotting and
+	// displaying it in godoc with the real URL) but does not execute it under "go test".
+	// Executing it made the suite flaky (the remote host intermittently returns HTTP 403),
+	// and the remote path exercises loads.JSONSpec + network rather than validate itself,
+	// which is already covered by the file-based examples and tests.
 }
 
 func ExampleSpecValidator_Validate() {
@@ -109,8 +113,12 @@ func ExampleSpecValidator_Validate_url() {
 		}
 	}
 
-	// Output:
-	// This spec is valid
+	// NOTE: this example loads a spec from a live remote URL, so it is intentionally left
+	// without an "// Output:" directive: Go compiles it (keeping it from bit-rotting and
+	// displaying it in godoc with the real URL) but does not execute it under "go test".
+	// Executing it made the suite flaky (the remote host intermittently returns HTTP 403),
+	// and the remote path exercises loads.JSONSpec + network rather than validate itself,
+	// which is already covered by the file-based examples and tests.
 }
 
 func ExampleAgainstSchema() {


### PR DESCRIPTION
ExampleSpec_second and ExampleSpecValidator_Validate_url load a spec from http://petstore.swagger.io/v2/swagger.json, a live host that intermittently returns HTTP 403, making the suite flaky.

Drop their "// Output:" directives so Go still compiles them (they remain in godoc with the real URL and cannot bit-rot) but no longer runs them under go test. The remote path exercises loads.JSONSpec + network rather than validate logic, which is already covered by the file-based examples and tests, so executed coverage is not lost. A note on each example explains why the directive is intentionally absent.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
