### PR TITLE
fix: read result validity before Merge redeems it to the pool

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -554,8 +554,12 @@ DEFINITIONS:
 		if schema.Required != nil { // Safeguard
 			for _, pn := range schema.Required {
 				red := s.validateRequiredProperties(pn, d, &schema) //#nosec
+				// NOTE: capture validity before merging: Merge may redeem `red` to the
+				// pool (wantsRedeemOnMerge), after which reading it races with a concurrent
+				// BorrowResult().cleared() in another goroutine sharing the global pool.
+				isValid := red.IsValid()
 				res.Merge(red)
-				if !red.IsValid() && !s.Options.ContinueOnErrors {
+				if !isValid && !s.Options.ContinueOnErrors {
 					break DEFINITIONS // there is an error, let's stop that bleeding
 				}
 			}


### PR DESCRIPTION
validateRequiredDefinitions read red.IsValid() *after* res.Merge(red). Merge redeems a result whose wantsRedeemOnMerge is set (true for any pool-borrowed result) back into the process-global sync.Pool. Reading red after that point races with a concurrent Spec() goroutine borrowing the same *Result and calling cleared() on it.

This surfaced as a rare data race under -race in Test_ParallelPool:

  Write at ... Result.cleared() <- resultsPool.BorrowResult()
  Previous read ... Result.IsValid() <- validateRequiredDefinitions

Capture validity into a local before merging, matching the read-before- merge pattern used everywhere else (e.g. validateRequiredProperties, default/example validators).

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
