### PR TITLE
tests: make schema fixtures deterministic

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -98,6 +98,7 @@ func ExampleSpecValidator_Validate_url() {
 	// Example of spec validation call with full result
 
 	// Example with the bundled Petstore spec:
+	// Also works with URL, e.g. http://petstore.swagger.io/v2/swagger.json
 	path := "fixtures/go-swagger/canary/petstore/swagger.json"
 	doc, err := loads.JSONSpec(path)
 	if err == nil {

--- a/doc_test.go
+++ b/doc_test.go
@@ -41,9 +41,9 @@ func ExampleSpec() {
 func ExampleSpec_second() {
 	// Example with high level spec validation call, without showing warnings
 
-	// Example with online spec URL:
-	url := "http://petstore.swagger.io/v2/swagger.json"
-	doc, err := loads.JSONSpec(url)
+	// Example with the bundled Petstore spec:
+	path := "fixtures/go-swagger/canary/petstore/swagger.json"
+	doc, err := loads.JSONSpec(path)
 	if err == nil {
 		validate.SetContinueOnErrors(true)         // Set global options
 		errs := validate.Spec(doc, strfmt.Default) // Validates spec with default Swagger 2.0 format definitions
@@ -96,9 +96,9 @@ func ExampleSpecValidator_Validate() {
 func ExampleSpecValidator_Validate_url() {
 	// Example of spec validation call with full result
 
-	// Example with online spec URL:
-	url := "http://petstore.swagger.io/v2/swagger.json"
-	doc, err := loads.JSONSpec(url)
+	// Example with the bundled Petstore spec:
+	path := "fixtures/go-swagger/canary/petstore/swagger.json"
+	doc, err := loads.JSONSpec(path)
 	if err == nil {
 		validator := validate.NewSpecValidator(doc.Schema(), strfmt.Default)
 		validator.SetContinueOnErrors(true)  // Set option for this validator

--- a/doc_test.go
+++ b/doc_test.go
@@ -42,6 +42,7 @@ func ExampleSpec_second() {
 	// Example with high level spec validation call, without showing warnings
 
 	// Example with the bundled Petstore spec:
+	// Also works with URL, e.g. http://petstore.swagger.io/v2/swagger.json
 	path := "fixtures/go-swagger/canary/petstore/swagger.json"
 	doc, err := loads.JSONSpec(path)
 	if err == nil {

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -104,7 +104,7 @@ func TestJSONSchemaSuite(t *testing.T) {
 		WriteTimeout: 10 * time.Second,
 		Handler:      http.FileServer(http.Dir(jsonSchemaFixturesPath + "/remotes")),
 	}
-	listener, err := net.Listen("tcp", "localhost:1234")
+	listener, err := new(net.ListenConfig).Listen(t.Context(), "tcp", "localhost:1234")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, svr.Close())

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -5,6 +5,8 @@ package validate
 
 import (
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -97,15 +99,18 @@ func isExtendedEnabled(nm string) bool {
 
 func TestJSONSchemaSuite(t *testing.T) {
 	// Internal local server to serve remote $ref
+	svr := &http.Server{
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		Handler:      http.FileServer(http.Dir(jsonSchemaFixturesPath + "/remotes")),
+	}
+	listener, err := net.Listen("tcp", "localhost:1234")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svr.Close())
+	})
 	go func() {
-		svr := &http.Server{
-			ReadTimeout:  5 * time.Second,
-			WriteTimeout: 10 * time.Second,
-			Addr:         "localhost:1234",
-			Handler:      http.FileServer(http.Dir(jsonSchemaFixturesPath + "/remotes")),
-		}
-		err := svr.ListenAndServe()
-		if err != nil {
+		if err := svr.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			panic(err.Error())
 		}
 	}()


### PR DESCRIPTION
This PR removes two sources of nondeterminism from the validation examples and schema tests:

- Create the local fixture listener synchronously before serving, so requests cannot race `ListenAndServe`.
- Use the repository-bundled Petstore document in examples instead of fetching `petstore.swagger.io`.

The cleanup path accepts the expected `http.ErrServerClosed`.

Tested with `go test ./...`.